### PR TITLE
Refactor/stream content

### DIFF
--- a/Junaid.GoogleGemini.Net/Infrastructure/IGeminiClient.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/IGeminiClient.cs
@@ -6,6 +6,6 @@
 
         Task<TResponse> PostAsync<TRequest, TResponse>(string endpoint, TRequest data);
 
-        IAsyncEnumerable<string> PostAsync<TRequest>(string endpoint, TRequest data);
+        IAsyncEnumerable<string> SendAsync<TRequest>(string endpoint, TRequest data);
     }
 }

--- a/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
+++ b/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
@@ -12,8 +12,8 @@
     <RepositoryUrl>https://github.com/jaslam94/Junaid.GoogleGemini.Net</RepositoryUrl>
     <PackageTags>GoogleGemini.Net; Google; Gemini; Gemini.Net; GenerativeAI; dotnet;</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReleaseNotes>Added count tokens method to all services.</PackageReleaseNotes>
-    <Version>3.1.0</Version>
+    <PackageReleaseNotes>Internal refactoring for the stream content method.</PackageReleaseNotes>
+    <Version>3.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Junaid.GoogleGemini.Net/Services/ChatService.cs
+++ b/Junaid.GoogleGemini.Net/Services/ChatService.cs
@@ -38,7 +38,7 @@ namespace Junaid.GoogleGemini.Net.Services
             {
                 model.ApplyConfiguration(configuration);
             }
-            await foreach (var data in GeminiClient.PostAsync($"/v1beta/models/gemini-pro:streamGenerateContent", model))
+            await foreach (var data in GeminiClient.SendAsync($"/v1beta/models/gemini-pro:streamGenerateContent", model))
             {
                 handleStreamResponse(data);
             }

--- a/Junaid.GoogleGemini.Net/Services/TextService.cs
+++ b/Junaid.GoogleGemini.Net/Services/TextService.cs
@@ -37,7 +37,7 @@ namespace Junaid.GoogleGemini.Net.Services
             {
                 model.ApplyConfiguration(configuration);
             }
-            await foreach (var data in GeminiClient.PostAsync($"/v1beta/models/gemini-pro:streamGenerateContent", model))
+            await foreach (var data in GeminiClient.SendAsync($"/v1beta/models/gemini-pro:streamGenerateContent", model))
             {
                 handleStreamResponse(data);
             }

--- a/Junaid.GoogleGemini.Net/Services/VisionService.cs
+++ b/Junaid.GoogleGemini.Net/Services/VisionService.cs
@@ -41,7 +41,7 @@ namespace Junaid.GoogleGemini.Net.Services
             {
                 model.ApplyConfiguration(configuration);
             }
-            await foreach (var data in GeminiClient.PostAsync($"/v1beta/models/gemini-pro-vision:streamGenerateContent", model))
+            await foreach (var data in GeminiClient.SendAsync($"/v1beta/models/gemini-pro-vision:streamGenerateContent", model))
             {
                 handleStreamResponse(data);
             }


### PR DESCRIPTION
Some internal refactoring for the stream content method.

Using `SendAsync` to make post requests with `HttpCompletionOption.ResponseHeadersRead` option which allows parsing partial response data.  Also using memory stream objects while making the request. These techniques reduce the memory consumption and improve performance [1].

**References** 
[1] https://code-maze.com/using-streams-with-httpclient-to-improve-performance-and-memory-usage/