### PR TITLE
Add netstandard2.0 target (broad-reach build)

### DIFF
--- a/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
+++ b/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
@@ -11,7 +11,7 @@
 		<Description>Microsoft.Extensions.AI adapters (IChatClient, IEmbeddingGenerator) for Junaid.GoogleGemini.Net — use Google Gemini anywhere the .NET AI abstractions are consumed.</Description>
 		<PackageTags>GoogleGemini;Gemini;Microsoft.Extensions.AI;IChatClient;AI;LLM;dotnet</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-alpha.3</Version>
+		<Version>6.0.0-alpha.4</Version>
 
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Junaid.GoogleGemini.Net/Extensions/GeminiExtensions.cs
+++ b/Junaid.GoogleGemini.Net/Extensions/GeminiExtensions.cs
@@ -5,10 +5,12 @@ using Junaid.GoogleGemini.Net.Services;
 using Junaid.GoogleGemini.Net.Services.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Http.Resilience;
 using Microsoft.Extensions.Options;
-using Polly;
 using System.Net;
+#if NET8_0_OR_GREATER
+using Microsoft.Extensions.Http.Resilience;
+using Polly;
+#endif
 
 namespace Junaid.GoogleGemini.Net.Extensions
 {
@@ -64,7 +66,7 @@ namespace Junaid.GoogleGemini.Net.Extensions
             });
 
             // Configure HTTP client with authentication
-            services.AddHttpClient<GeminiClient>((sp, client) =>
+            var clientBuilder = services.AddHttpClient<GeminiClient>((sp, client) =>
             {
                 var options = sp.GetRequiredService<IOptions<GeminiOptions>>().Value;
                 client.BaseAddress = options.BaseUrl;
@@ -93,12 +95,13 @@ namespace Junaid.GoogleGemini.Net.Extensions
                 return handler;
             })
             // Auth handler is registered first => it is the OUTERMOST handler, so it runs once and
-            // adds the API key a single time...
-            .AddHttpMessageHandler<GeminiAuthHandler>()
-            // ...and the resilience handler is INNER, so it retries the network send without
-            // re-running auth. Retries/backoff/transient-fault handling live here (not in the client),
-            // which is what makes retries correct: the buffered request is re-sent internally.
-            .AddResilienceHandler("gemini", static (builder, context) =>
+            // adds the API key a single time. The retry handler is INNER, so it re-sends the network
+            // request without re-running auth (the buffered request is safe to resend).
+            .AddHttpMessageHandler<GeminiAuthHandler>();
+
+#if NET8_0_OR_GREATER
+            // net8+: the battle-tested standard resilience handler (retry + backoff + jitter).
+            clientBuilder.AddResilienceHandler("gemini", static (builder, context) =>
             {
                 var resilienceOptions = context.ServiceProvider.GetRequiredService<IOptions<GeminiOptions>>().Value;
                 builder.AddRetry(new HttpRetryStrategyOptions
@@ -110,6 +113,14 @@ namespace Junaid.GoogleGemini.Net.Extensions
                     Delay = resilienceOptions.RetryBaseDelay,
                 });
             });
+#else
+            // netstandard2.0: Microsoft.Extensions.Http.Resilience isn't available, so use our own.
+            clientBuilder.AddHttpMessageHandler(sp =>
+            {
+                var resilienceOptions = sp.GetRequiredService<IOptions<GeminiOptions>>().Value;
+                return new GeminiRetryHandler(resilienceOptions.MaxRetries, resilienceOptions.RetryBaseDelay);
+            });
+#endif
 
             // Dedicated client for the Files API (host root + auth; no retry, since a partially
             // completed upload isn't safe to blindly replay).

--- a/Junaid.GoogleGemini.Net/Infrastructure/GeminiClient.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/GeminiClient.cs
@@ -87,7 +87,7 @@ public class GeminiClient : IGeminiClient
         var correlationId = Guid.NewGuid().ToString();
         var (operation, model) = GeminiTelemetry.Parse(endpoint);
         using var activity = GeminiTelemetry.StartOperation(operation, model);
-        var startedAt = Stopwatch.GetTimestamp();
+        var stopwatch = Stopwatch.StartNew();
 
         try
         {
@@ -135,7 +135,7 @@ public class GeminiClient : IGeminiClient
         }
         finally
         {
-            GeminiTelemetry.RecordDuration(operation, model, Stopwatch.GetElapsedTime(startedAt).TotalSeconds);
+            GeminiTelemetry.RecordDuration(operation, model, stopwatch.Elapsed.TotalSeconds);
         }
     }
 
@@ -153,7 +153,7 @@ public class GeminiClient : IGeminiClient
             }
 
             var json = JsonSerializer.Serialize(data, typeof(TRequest), _jsonOptions);
-            using var request = new HttpRequestMessage(HttpMethod.Patch, endpoint)
+            using var request = new HttpRequestMessage(new HttpMethod("PATCH"), endpoint)
             {
                 Content = new StringContent(json, Encoding.UTF8, "application/json")
             };
@@ -196,7 +196,7 @@ public class GeminiClient : IGeminiClient
                 return;
             }
 
-            var content = await response.Content.ReadAsStringAsync(cancellationToken);
+            var content = await response.Content.ReadStringAsync(cancellationToken);
             var geminiError = JsonSerializer.Deserialize<ApiErrorResponse>(content, _jsonOptions);
             throw new GeminiApiException(
                 geminiError?.Error?.Message ?? $"Request failed with status {(int)response.StatusCode}",
@@ -217,7 +217,7 @@ public class GeminiClient : IGeminiClient
     /// <summary>Deserializes a success response or maps an error response to a typed exception.</summary>
     private async Task<T> HandleResponse<T>(HttpResponseMessage response, string correlationId, CancellationToken cancellationToken = default)
     {
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+        var content = await response.Content.ReadStringAsync(cancellationToken);
 
         try
         {
@@ -290,7 +290,7 @@ public class GeminiClient : IGeminiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            var errorContent = await response.Content.ReadAsStringAsync(cancellationToken);
+            var errorContent = await response.Content.ReadStringAsync(cancellationToken);
             _logger.LogError("Stream request failed - Status: {StatusCode}, Response: {ResponseContent} [ID: {CorrelationId}]",
                 response.StatusCode, errorContent, correlationId);
 
@@ -301,7 +301,7 @@ public class GeminiClient : IGeminiClient
                 geminiError?.Error);
         }
 
-        var responseStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var responseStream = await response.Content.ReadStreamAsync(cancellationToken);
         using var reader = new StreamReader(responseStream);
         var chunkCount = 0;
         var dataBuffer = new StringBuilder();
@@ -310,7 +310,7 @@ public class GeminiClient : IGeminiClient
         {
             while (true)
             {
-                var line = await reader.ReadLineAsync(cancellationToken);
+                var line = await reader.ReadLineCancelableAsync(cancellationToken);
                 if (line is null) break; // end of stream
 
                 if (line.Length == 0)
@@ -329,7 +329,7 @@ public class GeminiClient : IGeminiClient
                 // We only care about the "data:" field; ignore comments (":..."), "event:", "id:", etc.
                 if (line.StartsWith("data:", StringComparison.Ordinal))
                 {
-                    dataBuffer.Append(line.AsSpan(5).TrimStart());
+                    dataBuffer.Append(line.Substring(5).TrimStart());
                 }
             }
 
@@ -344,7 +344,11 @@ public class GeminiClient : IGeminiClient
         finally
         {
             reader.Dispose();
+#if NET8_0_OR_GREATER
             await responseStream.DisposeAsync();
+#else
+            responseStream.Dispose();
+#endif
             _logger.LogDebug("Stream completed with {ChunkCount} chunks [ID: {CorrelationId}]", chunkCount, correlationId);
         }
     }

--- a/Junaid.GoogleGemini.Net/Infrastructure/GeminiRetryHandler.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/GeminiRetryHandler.cs
@@ -1,0 +1,54 @@
+namespace Junaid.GoogleGemini.Net.Infrastructure
+{
+    /// <summary>
+    /// A minimal retry <see cref="DelegatingHandler"/> used on <c>netstandard2.0</c>, where
+    /// Microsoft.Extensions.Http.Resilience isn't available. Retries transient failures (HTTP 429,
+    /// 5xx, and <see cref="HttpRequestException"/>) with exponential backoff.
+    /// </summary>
+    /// <remarks>
+    /// Re-sending the same request is safe here because the client always uses buffered content
+    /// (<see cref="StringContent"/>/<see cref="ByteArrayContent"/>): inner handlers re-read it each
+    /// attempt, and disposal only happens once the outer <see cref="HttpClient"/> call completes.
+    /// On net8+ the standard resilience handler is used instead (see GeminiExtensions).
+    /// </remarks>
+    internal sealed class GeminiRetryHandler : DelegatingHandler
+    {
+        private readonly int _maxRetries;
+        private readonly TimeSpan _baseDelay;
+
+        public GeminiRetryHandler(int maxRetries, TimeSpan baseDelay)
+        {
+            _maxRetries = Math.Max(0, maxRetries);
+            _baseDelay = baseDelay <= TimeSpan.Zero ? TimeSpan.FromSeconds(1) : baseDelay;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            for (var attempt = 0; ; attempt++)
+            {
+                try
+                {
+                    var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+                    if (attempt >= _maxRetries || !IsTransient(response.StatusCode))
+                    {
+                        return response;
+                    }
+                    response.Dispose(); // discard the transient response before retrying
+                }
+                catch (HttpRequestException) when (attempt < _maxRetries)
+                {
+                    // fall through to backoff and retry
+                }
+
+                var delayMs = _baseDelay.TotalMilliseconds * Math.Pow(2, attempt);
+                await Task.Delay(TimeSpan.FromMilliseconds(delayMs), cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        private static bool IsTransient(System.Net.HttpStatusCode statusCode)
+        {
+            var code = (int)statusCode;
+            return code == 429 || code >= 500;
+        }
+    }
+}

--- a/Junaid.GoogleGemini.Net/Infrastructure/HttpPolyfills.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/HttpPolyfills.cs
@@ -1,0 +1,32 @@
+using System.IO;
+
+namespace Junaid.GoogleGemini.Net.Infrastructure;
+
+/// <summary>
+/// Small shims for cancellation-aware APIs that exist on net8+ but not on netstandard2.0. On the
+/// older surface the token is honored where the BCL allows and otherwise ignored, so call sites can
+/// stay single-source across all target frameworks.
+/// </summary>
+internal static class HttpPolyfills
+{
+    public static Task<string> ReadStringAsync(this HttpContent content, CancellationToken cancellationToken)
+#if NET8_0_OR_GREATER
+        => content.ReadAsStringAsync(cancellationToken);
+#else
+        => content.ReadAsStringAsync();
+#endif
+
+    public static Task<Stream> ReadStreamAsync(this HttpContent content, CancellationToken cancellationToken)
+#if NET8_0_OR_GREATER
+        => content.ReadAsStreamAsync(cancellationToken);
+#else
+        => content.ReadAsStreamAsync();
+#endif
+
+    public static Task<string?> ReadLineCancelableAsync(this StreamReader reader, CancellationToken cancellationToken)
+#if NET8_0_OR_GREATER
+        => reader.ReadLineAsync(cancellationToken).AsTask();
+#else
+        => reader.ReadLineAsync();
+#endif
+}

--- a/Junaid.GoogleGemini.Net/Infrastructure/Serialization/JsonSchemaGenerator.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/Serialization/JsonSchemaGenerator.cs
@@ -71,7 +71,9 @@ internal static class JsonSchemaGenerator
 
         var properties = new JsonObject();
         var required = new JsonArray();
+#if NET8_0_OR_GREATER
         var nullability = new NullabilityInfoContext();
+#endif
 
         foreach (var prop in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
         {
@@ -81,8 +83,13 @@ internal static class JsonSchemaGenerator
             var name = prop.GetCustomAttribute<JsonPropertyNameAttribute>()?.Name ?? prop.Name;
             properties[name] = Build(prop.PropertyType, visited);
 
-            var isNullable = Nullable.GetUnderlyingType(prop.PropertyType) is not null
-                || nullability.Create(prop).WriteState == NullabilityState.Nullable;
+            // A property is required unless it's a Nullable<T> value type, or (net8+) a nullable
+            // reference type. netstandard2.0 lacks NullabilityInfoContext, so we can only detect the
+            // Nullable<T> case there — a conservative, still-valid schema.
+            var isNullable = Nullable.GetUnderlyingType(prop.PropertyType) is not null;
+#if NET8_0_OR_GREATER
+            isNullable = isNullable || nullability.Create(prop).WriteState == NullabilityState.Nullable;
+#endif
             if (!isNullable)
             {
                 required.Add(name);

--- a/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
+++ b/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
@@ -8,20 +8,23 @@
 
 	<PropertyGroup>
 		<!--
-			Multi-target: net8.0 (current LTS) and net9.0 (current STS). netstandard2.0 is planned
-			for Phase 1, where the transport rewrite lets us add the needed polyfills cleanly
-			(IAsyncEnumerable, CancellationToken stream overloads).
+			Multi-target: net8.0 (LTS), net9.0 (STS), and netstandard2.0 for maximum reach
+			(.NET Framework 4.6.1+, Mono, Unity, Xamarin). The netstandard2.0 build relies on the
+			polyfill packages below for APIs missing from that older surface.
 		-->
-		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;net9.0;netstandard2.0</TargetFrameworks>
 
 		<!-- Package metadata -->
 		<Title>Junaid.GoogleGemini.Net</Title>
 		<Description>A production-ready .NET client for the Google Gemini API: resilient (retries + rate limiting), observable, and DI-native, with first-class ASP.NET Core ergonomics.</Description>
 		<PackageTags>GoogleGemini;Gemini;GenerativeAI;AI;LLM;GoogleAI;dotnet;aspnetcore;IChatClient</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-alpha.3</Version>
+		<Version>6.0.0-alpha.4</Version>
 		<PackageReleaseNotes>
-			6.0 alpha.3 adds the differentiation layer on top of the modern feature set:
+			6.0 alpha.4 adds a netstandard2.0 target for maximum reach (.NET Framework 4.6.1+, Mono,
+			Unity, Xamarin), using polyfills and a built-in retry handler where the modern resilience
+			package isn't available. net8/net9 are unchanged.
+			6.0 alpha.3 added the differentiation layer on top of the modern feature set:
 			- Microsoft.Extensions.AI adapters (IChatClient / IEmbeddingGenerator) via the
 			  companion package Junaid.GoogleGemini.Net.Extensions.AI.
 			- OpenTelemetry-native tracing + token/latency metrics (GenAI semantic conventions),
@@ -66,10 +69,29 @@
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="8.0.0" />
-		<!-- Modern resilience (Polly v8 under the hood). Replaces the deprecated Polly.Extensions.Http
-		     and the hand-rolled retry cache: resilience now lives on the HttpClient pipeline. -->
-		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
 		<PackageReference Include="System.Threading.RateLimiting" Version="8.0.0" />
+	</ItemGroup>
+
+	<!-- Modern resilience (Polly v8 under the hood) on the HttpClient pipeline. Net8+ only — this
+	     package has no netstandard2.0 asset, so the ns2.0 build uses GeminiRetryHandler instead. -->
+	<ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
+	</ItemGroup>
+
+	<!--
+		Polyfills for the netstandard2.0 target only:
+		- System.Text.Json: in-box on net8/9, a package here (brings the source generator too).
+		- Microsoft.Bcl.AsyncInterfaces: IAsyncEnumerable / IAsyncDisposable.
+		- PolySharp: generates compiler-required shims (init/record, required members, nullable and
+		  [EnumeratorCancellation] attributes) so modern C# compiles on the old surface. Dev-only.
+	-->
+	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+		<PackageReference Include="PolySharp" Version="1.14.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 </Project>

--- a/Junaid.GoogleGemini.Net/Services/CachingService.cs
+++ b/Junaid.GoogleGemini.Net/Services/CachingService.cs
@@ -24,7 +24,7 @@ namespace Junaid.GoogleGemini.Net.Services
         /// <inheritdoc/>
         public Task<CachedContent> CreateAsync(CachedContent content, CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(content);
+            if (content is null) throw new ArgumentNullException(nameof(content));
             if (string.IsNullOrWhiteSpace(content.Model))
             {
                 throw new ArgumentException("CachedContent.Model is required (e.g. 'models/gemini-2.5-flash').", nameof(content));

--- a/Junaid.GoogleGemini.Net/Services/FileService.cs
+++ b/Junaid.GoogleGemini.Net/Services/FileService.cs
@@ -25,7 +25,7 @@ namespace Junaid.GoogleGemini.Net.Services
         /// <summary>Initializes a new instance of the <see cref="FileService"/>.</summary>
         public FileService(IHttpClientFactory httpClientFactory, ILogger<FileService> logger)
         {
-            ArgumentNullException.ThrowIfNull(httpClientFactory);
+            if (httpClientFactory is null) throw new ArgumentNullException(nameof(httpClientFactory));
             _httpClient = httpClientFactory.CreateClient(GeminiHttpClients.Files);
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
@@ -37,7 +37,7 @@ namespace Junaid.GoogleGemini.Net.Services
             string? displayName = null,
             CancellationToken cancellationToken = default)
         {
-            ArgumentNullException.ThrowIfNull(content);
+            if (content is null) throw new ArgumentNullException(nameof(content));
             if (string.IsNullOrWhiteSpace(mimeType))
             {
                 throw new ArgumentException("MIME type is required.", nameof(mimeType));
@@ -71,7 +71,7 @@ namespace Junaid.GoogleGemini.Net.Services
             using var uploadResponse = await _httpClient.SendAsync(uploadRequest, cancellationToken);
             await EnsureSuccessAsync(uploadResponse, "finalize file upload", cancellationToken);
 
-            var body = await uploadResponse.Content.ReadAsStringAsync(cancellationToken);
+            var body = await uploadResponse.Content.ReadStringAsync(cancellationToken);
             var parsed = Deserialize<FileUploadResponse>(body);
             return parsed?.File
                 ?? throw new GeminiSerializationException("The upload response did not contain a file.");
@@ -83,7 +83,7 @@ namespace Junaid.GoogleGemini.Net.Services
             using var response = await _httpClient.GetAsync($"{Version}/{Normalize(name)}", cancellationToken);
             await EnsureSuccessAsync(response, "get file", cancellationToken);
 
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var body = await response.Content.ReadStringAsync(cancellationToken);
             return Deserialize<FileResource>(body)
                 ?? throw new GeminiSerializationException($"No metadata returned for file '{name}'.");
         }
@@ -102,7 +102,7 @@ namespace Junaid.GoogleGemini.Net.Services
             using var response = await _httpClient.GetAsync($"{Version}/files{suffix}", cancellationToken);
             await EnsureSuccessAsync(response, "list files", cancellationToken);
 
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var body = await response.Content.ReadStringAsync(cancellationToken);
             return Deserialize<FileListResponse>(body) ?? new FileListResponse();
         }
 
@@ -172,7 +172,7 @@ namespace Junaid.GoogleGemini.Net.Services
                 return;
             }
 
-            var body = await response.Content.ReadAsStringAsync(cancellationToken);
+            var body = await response.Content.ReadStringAsync(cancellationToken);
             _logger.LogError("Files API {Operation} failed - Status: {StatusCode}, Body: {Body}",
                 operation, response.StatusCode, body);
 

--- a/Junaid.GoogleGemini.Net/Services/ModelInfoService.cs
+++ b/Junaid.GoogleGemini.Net/Services/ModelInfoService.cs
@@ -43,9 +43,9 @@ namespace Junaid.GoogleGemini.Net.Services
                     // Cache individual models for future GetModelAsync calls
                     foreach (var model in response!.Models)
                     {
-                        if (!string.IsNullOrEmpty(model.Name))
+                        if (model.Name is { Length: > 0 } modelName)
                         {
-                            _modelCache.Set(model.Name, model, _cacheDuration);
+                            _modelCache.Set(modelName, model, _cacheDuration);
                         }
                     }
                 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,7 +123,7 @@ grounding, url_context, code_execution) + groundingMetadata; embeddings (taskTyp
 - [x] Documented resilience + rate-limiting story; sensible production defaults.
 - [x] Refreshed README with the "why choose this" matrix and accurate 6.0 examples.
 - [ ] First-class ASP.NET Core minimal-API sample; DocFX/docs site. *(still open)*
-- [ ] `netstandard2.0` target with polyfills. *(still open)*
+- [x] `netstandard2.0` target with polyfills (alpha.4) — PolySharp + Microsoft.Bcl.AsyncInterfaces + System.Text.Json package + a hand-written GeminiRetryHandler where Microsoft.Extensions.Http.Resilience (net8+ only) isn't available.
 
 **Ships as:** `6.0.0` — the production-grade DX release.
 


### PR DESCRIPTION
## Summary

Adds a **netstandard2.0** target to the core package so it can be consumed from .NET Framework 4.6.1+, Mono, Unity, and Xamarin — reach the big competitors have and we didn't. `net8.0`/`net9.0` are unchanged.

## How

netstandard2.0 lacks several modern APIs, handled via:
- **PolySharp** (dev-only): generates `init`/record/`required`/nullable + `[EnumeratorCancellation]` attributes and `Index`/`Range`.
- **Microsoft.Bcl.AsyncInterfaces**: `IAsyncEnumerable` for streaming.
- **System.Text.Json** package (in-box on net8/9) — incl. the source generator.
- **`HttpPolyfills`**: shims for the `CancellationToken` overloads of `ReadAsStringAsync`/`ReadAsStreamAsync`/`ReadLineAsync` missing on ns2.0.
- **`GeminiRetryHandler`**: a small transient-retry `DelegatingHandler` used on ns2.0, because `Microsoft.Extensions.Http.Resilience` has **no ns2.0 asset**. net8+ keeps the standard resilience handler (conditional in `GeminiExtensions`).
- Portable fixes: `Stopwatch` instance vs `GetElapsedTime`, `new HttpMethod("PATCH")`, manual null checks vs `ArgumentNullException.ThrowIfNull`, `NullabilityInfoContext` guarded behind net8, `Substring` vs `Append(ReadOnlySpan)`, `Dispose` vs `DisposeAsync`.

## Verification
- All three TFMs build clean under `TreatWarningsAsErrors`.
- The `.nupkg` ships `lib/net8.0`, `lib/net9.0`, `lib/netstandard2.0`.
- 25/25 tests green on net8.0 + net9.0 (ns2.0 is a library target; runtime validation on .NET Framework is a follow-up).
- Bumped both packages to `6.0.0-alpha.4`.

> Note: tests run on net8/net9 (you can't execute a netstandard2.0 library directly). The ns2.0 build is compile-verified; a .NET Framework test host would be the next step to validate runtime behavior there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)