### PR TITLE
Add ASP.NET Core sample + DocFX documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,45 @@
+name: Docs
+
+# Builds the DocFX site and publishes it to GitHub Pages.
+# Requires: repo Settings → Pages → Source = "GitHub Actions".
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+      - name: Install DocFX
+        run: dotnet tool update -g docfx
+      - name: Build docs
+        run: docfx docs/docfx.json
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/Junaid.GoogleGemini.Net.sln
+++ b/Junaid.GoogleGemini.Net.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Junaid.GoogleGemini.Net.Tes
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Junaid.GoogleGemini.Net.Extensions.AI", "Junaid.GoogleGemini.Net.Extensions.AI\Junaid.GoogleGemini.Net.Extensions.AI.csproj", "{E6F3E3E9-21FC-475D-BD6E-ECB48CA5886F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{5D20AA90-6969-D8BD-9DCD-8634F4692FDA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Junaid.GoogleGemini.Net.AspNetCoreSample", "samples\Junaid.GoogleGemini.Net.AspNetCoreSample\Junaid.GoogleGemini.Net.AspNetCoreSample.csproj", "{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,12 +75,25 @@ Global
 		{E6F3E3E9-21FC-475D-BD6E-ECB48CA5886F}.Release|x64.Build.0 = Release|Any CPU
 		{E6F3E3E9-21FC-475D-BD6E-ECB48CA5886F}.Release|x86.ActiveCfg = Release|Any CPU
 		{E6F3E3E9-21FC-475D-BD6E-ECB48CA5886F}.Release|x86.Build.0 = Release|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Debug|x64.Build.0 = Debug|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Debug|x86.Build.0 = Debug|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|x64.ActiveCfg = Release|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|x64.Build.0 = Release|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|x86.ActiveCfg = Release|Any CPU
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{09EA83CD-C324-48D2-A41F-248C2E255110} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6CB5F522-7B50-4320-A3FC-C23F2BDA4550}

--- a/README.md
+++ b/README.md
@@ -212,9 +212,14 @@ builder.Services.AddGemini(options =>
 
 Failures surface as typed exceptions: `GeminiApiException` (status + parsed error), `GeminiRateLimitException`, `GeminiTimeoutException`, `GeminiSerializationException`, `GeminiContentException` — all deriving from `GeminiException`.
 
+## Documentation & samples
+
+- **Guides + full API reference**: the [`docs/`](docs/) DocFX site (Getting started, structured output, streaming, resilience, observability, M.E.AI, files & caching, and a v5→v6 migration guide). Published to GitHub Pages via the Docs workflow.
+- **Runnable sample**: [`samples/Junaid.GoogleGemini.Net.AspNetCoreSample`](samples/Junaid.GoogleGemini.Net.AspNetCoreSample) — a minimal ASP.NET Core API showing generation, `GenerateAsync<T>`, streaming, `IChatClient`, and OpenTelemetry.
+
 ## Requirements
 
-- **.NET 8.0 or .NET 9.0**
+- **.NET 8.0, .NET 9.0, or any netstandard2.0 runtime** (.NET Framework 4.6.1+, Mono, Unity)
 - A **Google AI Studio API key**
 
 ## Contributing & support

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,5 @@
+# DocFX generated output (built by CI / locally; not committed)
+_site/
+api/*.yml
+api/.manifest
+obj/

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,11 @@
+# API reference
+
+This section is generated from the library's XML documentation. Browse the namespaces on the left,
+or use search.
+
+Key entry points:
+
+- **`Junaid.GoogleGemini.Net.Services.Interfaces.IGeminiService`** — generation, chat, streaming, structured output, token counting.
+- **`Junaid.GoogleGemini.Net.Extensions.GeminiExtensions`** — `AddGemini(...)` DI registration.
+- **`Junaid.GoogleGemini.Net.Models.Requests.GeminiRequestOptions`** — per-request options.
+- **`Junaid.GoogleGemini.Net.Infrastructure.Telemetry.GeminiTelemetry`** — the OpenTelemetry source/meter name.

--- a/docs/articles/extensions-ai.md
+++ b/docs/articles/extensions-ai.md
@@ -1,0 +1,54 @@
+# Microsoft.Extensions.AI integration
+
+The companion package `Junaid.GoogleGemini.Net.Extensions.AI` adapts Gemini to the standard .NET AI
+abstractions, so it works with Semantic Kernel, agent frameworks, and any middleware built on
+`IChatClient` / `IEmbeddingGenerator`.
+
+```shell
+dotnet add package Junaid.GoogleGemini.Net.Extensions.AI
+```
+
+## Register
+
+```csharp
+builder.Services.AddGemini(builder.Configuration.GetSection("Gemini"));
+builder.Services.AddGeminiChatClient("gemini-2.5-flash");            // IChatClient
+builder.Services.AddGeminiEmbeddingGenerator("gemini-embedding-001"); // IEmbeddingGenerator
+```
+
+## Use IChatClient
+
+```csharp
+public class Assistant(IChatClient chat)
+{
+    public async Task<string> Ask(string question)
+    {
+        var response = await chat.GetResponseAsync(
+            [new ChatMessage(ChatRole.User, question)]);
+        return response.Text;
+    }
+}
+```
+
+Streaming works through the same abstraction:
+
+```csharp
+await foreach (var update in chat.GetStreamingResponseAsync(messages))
+    Console.Write(update.Text);
+```
+
+## Use IEmbeddingGenerator
+
+```csharp
+public class Indexer(IEmbeddingGenerator<string, Embedding<float>> embeddings)
+{
+    public async Task<ReadOnlyMemory<float>> Embed(string text)
+    {
+        var result = await embeddings.GenerateAsync([text]);
+        return result[0].Vector;
+    }
+}
+```
+
+System messages, `ChatOptions` (model, temperature, max tokens, stop sequences, seed), finish reasons,
+and token usage are mapped across automatically.

--- a/docs/articles/files-and-caching.md
+++ b/docs/articles/files-and-caching.md
@@ -1,0 +1,45 @@
+# Files & context caching
+
+## Files API
+
+Upload large media once and reference it by URI instead of inlining bytes. Inject `IFileService`.
+
+```csharp
+var file = await files.UploadFileAsync(bytes, "video/mp4", "clip.mp4");
+
+// Video/audio must finish processing before use:
+await files.WaitUntilActiveAsync(file.Name!);
+
+// Other operations:
+var info = await files.GetFileAsync(file.Name!);
+var list = await files.ListFilesAsync(pageSize: 20);
+await files.DeleteFileAsync(file.Name!);
+```
+
+Uploads use the resumable protocol over a dedicated HttpClient. Reference an uploaded file in a
+request with a `FileData` part (`MimeType` + `FileUri`).
+
+## Context caching
+
+Cache a large, reused payload (long context, system instruction, tools) once, then reference it by
+name from later requests to save tokens and latency. Inject `ICachingService`.
+
+```csharp
+var cache = await caching.CreateAsync(new CachedContent
+{
+    Model = "models/gemini-2.5-flash",
+    Contents = [ /* large shared context */ ],
+    Ttl = "3600s",
+});
+
+var answer = await gemini.GenerateAsync(
+    "Summarize the document.",
+    new GeminiRequestOptions { CachedContent = cache.Name });
+
+// Manage the cache:
+await caching.UpdateTtlAsync(cache.Name!, "7200s");
+var all = await caching.ListAsync();
+await caching.DeleteAsync(cache.Name!);
+```
+
+The response's `Usage.CachedContentTokenCount` shows how many tokens were served from the cache.

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -1,0 +1,75 @@
+# Getting started
+
+## Install
+
+```shell
+dotnet add package Junaid.GoogleGemini.Net
+# optional: Microsoft.Extensions.AI adapters
+dotnet add package Junaid.GoogleGemini.Net.Extensions.AI
+```
+
+Targets **net8.0**, **net9.0**, and **netstandard2.0** (for .NET Framework / Unity / Mono).
+
+## Authenticate
+
+Get a key from [Google AI Studio](https://aistudio.google.com/app/apikey). Provide it via the
+`GeminiApiKey` environment variable or configuration:
+
+```json
+{
+  "Gemini": {
+    "ApiKey": "your-api-key",
+    "DefaultModel": "gemini-2.5-flash",
+    "TimeoutSeconds": 30,
+    "MaxRetries": 3,
+    "RateLimit": { "Enabled": true, "RequestsPerMinute": 60 }
+  }
+}
+```
+
+## Register
+
+```csharp
+builder.Services.AddGemini(builder.Configuration.GetSection("Gemini"));
+// or:
+builder.Services.AddGemini(options => options.ApiKey = "...");
+```
+
+## Use
+
+```csharp
+public class MyService(IGeminiService gemini)
+{
+    public async Task<string> Ask(string prompt)
+    {
+        var response = await gemini.GenerateAsync(prompt);
+        return response.Text();
+    }
+}
+```
+
+### Reading responses
+
+`Text()` returns the text, or an **empty string** when there is none (never a placeholder). To
+distinguish "no content":
+
+```csharp
+if (response.TryGetText(out var text)) { /* use text */ }
+string guaranteed = response.GetTextOrThrow();   // throws GeminiContentException if blocked/empty
+var finishReason = response.FinishReason;          // "STOP", "SAFETY", ...
+var usage = response.Usage;                         // token counts
+```
+
+### Errors
+
+All failures derive from `GeminiException`:
+
+| Type | When |
+|---|---|
+| `GeminiApiException` | API returned a non-success status (carries `StatusCode`, parsed `Error`) |
+| `GeminiRateLimitException` | the client-side rate limiter rejected the call |
+| `GeminiTimeoutException` | the request timed out |
+| `GeminiSerializationException` | a payload couldn't be (de)serialized |
+| `GeminiContentException` | `GetTextOrThrow()` found no usable text |
+
+Next: [Structured output](structured-output.md).

--- a/docs/articles/migration-v5-to-v6.md
+++ b/docs/articles/migration-v5-to-v6.md
@@ -1,0 +1,63 @@
+# Migrating from v5 to v6
+
+v6 is a modernization release with intentional breaking changes. The fixes below address real
+correctness bugs in v5 (retries that never worked, fragile streaming) — the upgrade is worth it.
+
+## Breaking changes
+
+### Response models are PascalCase
+Wire DTO members are now idiomatic PascalCase.
+
+```csharp
+// v5
+var n = tokens.totalTokens;
+var c = response.candidates[0];
+
+// v6
+var n = tokens.TotalTokens;
+var c = response.Candidates![0];
+```
+
+### Streaming returns `IAsyncEnumerable`
+```csharp
+// v5
+await gemini.StreamAsync(prompt, chunk => Console.Write(chunk));
+
+// v6 — primary API
+await foreach (var chunk in gemini.StreamAsync(prompt))
+    Console.Write(chunk.Text());
+
+// v6 — the callback overload still exists
+await gemini.StreamAsync(prompt, text => Console.Write(text));
+```
+
+### `Text()` no longer returns placeholder strings
+It returns the text, or an **empty string** when there is none (instead of sentences like
+`"[Content was blocked...]"`). Use `TryGetText` / `GetTextOrThrow` to detect missing content, and
+`FinishReason` / `BlockReason` to see why.
+
+### Typed exceptions
+`GeminiException` is now the base type. Status code and parsed error moved to `GeminiApiException`.
+
+```csharp
+// v5
+catch (GeminiException ex) { var code = ex.StatusCode; }
+
+// v6
+catch (GeminiApiException ex) { var code = ex.StatusCode; var status = ex.Status; }
+```
+
+### Defaults
+- The client now targets the **v1beta** API by default (unlocks structured output, thinking,
+  grounding, caching, the Files API).
+- Deprecated model fallbacks (e.g. `gemini-1.5-pro`) were removed; vision uses your default model.
+
+## New in v6
+
+- `GenerateAsync<T>` structured output
+- System instructions, thinking config, JSON mode
+- Tools: Google Search grounding, URL context, code execution; function declarations
+- Files API and context caching
+- OpenTelemetry traces & metrics
+- `Microsoft.Extensions.AI` adapters (`IChatClient`, `IEmbeddingGenerator`)
+- `netstandard2.0` target

--- a/docs/articles/observability.md
+++ b/docs/articles/observability.md
@@ -1,0 +1,39 @@
+# Observability (OpenTelemetry)
+
+The library emits traces and metrics via `System.Diagnostics`, following the OpenTelemetry **GenAI
+semantic conventions**. There is **no OpenTelemetry package dependency** — you opt in by subscribing
+to the source and meter. If nobody listens, overhead is negligible.
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithTracing(t => t.AddSource(GeminiTelemetry.SourceName))
+    .WithMetrics(m => m.AddMeter(GeminiTelemetry.SourceName));
+```
+
+`GeminiTelemetry.SourceName` is `"Junaid.GoogleGemini.Net"`.
+
+## What you get
+
+**Spans** (one per API call) tagged with:
+
+- `gen_ai.system` = `gemini`
+- `gen_ai.operation.name` (e.g. `generateContent`)
+- `gen_ai.request.model`
+- `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`
+- `gen_ai.response.finish_reasons`
+- error status on failures
+
+**Metrics**:
+
+- `gen_ai.client.operation.duration` (histogram, seconds)
+- `gen_ai.client.token.usage` (histogram, tagged `gen_ai.token.type` = input/output)
+
+## Exporting
+
+Add any OpenTelemetry exporter — console, OTLP, Azure Monitor, etc. For example, the console exporter
+(used by the ASP.NET Core sample):
+
+```csharp
+.WithTracing(t => t.AddSource(GeminiTelemetry.SourceName).AddConsoleExporter())
+.WithMetrics(m => m.AddMeter(GeminiTelemetry.SourceName).AddConsoleExporter());
+```

--- a/docs/articles/resilience-and-rate-limiting.md
+++ b/docs/articles/resilience-and-rate-limiting.md
@@ -1,0 +1,36 @@
+# Resilience & rate limiting
+
+Both are configured once and applied automatically to every call.
+
+```csharp
+builder.Services.AddGemini(options =>
+{
+    options.MaxRetries = 3;                          // retried on 429/5xx/transient faults
+    options.RetryBaseDelay = TimeSpan.FromSeconds(2); // exponential backoff base
+    options.RateLimit.Enabled = true;                // client-side token bucket
+    options.RateLimit.RequestsPerMinute = 60;
+});
+```
+
+## Retries
+
+On **net8.0/net9.0** retries run on the `HttpClient` pipeline via
+`Microsoft.Extensions.Http.Resilience` (Polly v8) — exponential backoff with jitter, retrying HTTP
+429, 5xx, `HttpRequestException`, and timeouts.
+
+On **netstandard2.0** (where that package isn't available) an equivalent built-in
+`GeminiRetryHandler` is used instead.
+
+Either way, retries happen *inside* a single logical send against buffered content, so a request is
+never corrupted by being half-sent — the bug that plagued earlier hand-rolled retry code.
+
+## Client-side rate limiting
+
+A token-bucket limiter (built on `System.Threading.RateLimiting`) caps outgoing requests before they
+leave your process, smoothing bursts and helping you stay under quota. When the limiter rejects a
+call you get a `GeminiRateLimitException`. Disable it with `RateLimit.Enabled = false`.
+
+## Timeouts
+
+`TimeoutSeconds` bounds each request; on expiry you get a `GeminiTimeoutException`. Genuine caller
+cancellation (your `CancellationToken`) propagates as `OperationCanceledException` instead.

--- a/docs/articles/streaming.md
+++ b/docs/articles/streaming.md
@@ -1,0 +1,48 @@
+# Streaming
+
+Streaming uses Server-Sent Events under the hood and is surfaced as `IAsyncEnumerable`.
+
+```csharp
+await foreach (var chunk in gemini.StreamAsync("Tell me a long story"))
+{
+    Console.Write(chunk.Text());
+}
+```
+
+Each `chunk` is a full `GenerateContentResponse`, so you also get `FinishReason`, `Usage`, and any
+grounding metadata on the final chunks.
+
+## Callback overload
+
+For simple cases there's a callback overload:
+
+```csharp
+await gemini.StreamAsync("Tell me a long story", text => Console.Write(text));
+```
+
+## Cancellation
+
+Pass a `CancellationToken`; it cancels the underlying HTTP read promptly:
+
+```csharp
+await foreach (var chunk in gemini.StreamAsync(prompt, cancellationToken: ct))
+{
+    ...
+}
+```
+
+## In ASP.NET Core
+
+Return the `IAsyncEnumerable` and the framework streams it:
+
+```csharp
+app.MapGet("/stream", (IGeminiService gemini, string prompt, CancellationToken ct)
+    => Stream(gemini, prompt, ct));
+
+static async IAsyncEnumerable<string> Stream(
+    IGeminiService gemini, string prompt, [EnumeratorCancellation] CancellationToken ct)
+{
+    await foreach (var chunk in gemini.StreamAsync(prompt, cancellationToken: ct))
+        yield return chunk.Text();
+}
+```

--- a/docs/articles/structured-output.md
+++ b/docs/articles/structured-output.md
@@ -1,0 +1,33 @@
+# Structured output
+
+`GenerateAsync<T>` returns a strongly-typed result. A JSON schema is derived from `T` automatically,
+the request is constrained to JSON output, and the reply is deserialized for you.
+
+```csharp
+record Recipe(string Title, string[] Ingredients, int Minutes);
+
+Recipe recipe = await gemini.GenerateAsync<Recipe>("A quick pasta recipe");
+Console.WriteLine(recipe.Title);
+```
+
+## How it works
+
+1. A schema is generated from `T` (property names, types, required-ness).
+2. `responseMimeType = application/json` and `responseSchema` are set on the request.
+3. The model's JSON reply is deserialized into `T`.
+
+You can still pass options (model, temperature, system instruction); the schema and MIME type are
+filled in only if you didn't set them:
+
+```csharp
+var person = await gemini.GenerateAsync<Person>(
+    "Pick a famous scientist.",
+    new GeminiRequestOptions { Model = "gemini-2.5-pro", Temperature = 0.2f });
+```
+
+## Tips
+
+- Prefer simple classes/records with `string`, numbers, `bool`, enums, arrays/lists, and nested objects.
+- Mark optional members nullable (`string?`) — non-nullable members are marked **required** in the schema.
+- Dictionaries aren't modeled (treated as plain objects); use explicit properties.
+- If deserialization fails, a `GeminiSerializationException` is thrown.

--- a/docs/articles/toc.yml
+++ b/docs/articles/toc.yml
@@ -1,0 +1,16 @@
+- name: Getting started
+  href: getting-started.md
+- name: Structured output
+  href: structured-output.md
+- name: Streaming
+  href: streaming.md
+- name: Resilience & rate limiting
+  href: resilience-and-rate-limiting.md
+- name: Observability
+  href: observability.md
+- name: Microsoft.Extensions.AI
+  href: extensions-ai.md
+- name: Files & caching
+  href: files-and-caching.md
+- name: Migrating v5 → v6
+  href: migration-v5-to-v6.md

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -1,0 +1,34 @@
+{
+  "metadata": [
+    {
+      "src": [
+        {
+          "files": [
+            "Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj",
+            "Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj"
+          ],
+          "src": ".."
+        }
+      ],
+      "dest": "api",
+      "properties": {
+        "TargetFramework": "net9.0"
+      }
+    }
+  ],
+  "build": {
+    "content": [
+      { "files": ["api/**.yml", "api/index.md"] },
+      { "files": ["articles/**.md", "articles/**/toc.yml", "toc.yml", "*.md"] }
+    ],
+    "output": "_site",
+    "template": ["default", "modern"],
+    "globalMetadata": {
+      "_appName": "Junaid.GoogleGemini.Net",
+      "_appTitle": "Junaid.GoogleGemini.Net",
+      "_description": "A production-ready .NET client for the Google Gemini API.",
+      "_enableSearch": true,
+      "_disableContribution": true
+    }
+  }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,33 @@
+# Junaid.GoogleGemini.Net
+
+A **production-ready** .NET client for the [Google Gemini API](https://ai.google.dev/) — resilient, observable, DI-native, and built to feel right in ASP.NET Core.
+
+It covers the modern Gemini surface (structured output, system instructions, thinking, grounding, the Files API, context caching), but what makes it worth choosing is everything *around* the API call: built-in retries, client-side rate limiting, OpenTelemetry-native traces & metrics, and first-class `Microsoft.Extensions.AI` adapters.
+
+## Get started
+
+```shell
+dotnet add package Junaid.GoogleGemini.Net
+```
+
+```csharp
+builder.Services.AddGemini(builder.Configuration.GetSection("Gemini"));
+
+app.MapGet("/", async (IGeminiService gemini) =>
+    (await gemini.GenerateAsync("Say hello!")).Text());
+```
+
+## Guides
+
+- [Getting started](articles/getting-started.md)
+- [Structured output (`GenerateAsync<T>`)](articles/structured-output.md)
+- [Streaming](articles/streaming.md)
+- [Resilience & rate limiting](articles/resilience-and-rate-limiting.md)
+- [Observability (OpenTelemetry)](articles/observability.md)
+- [Microsoft.Extensions.AI integration](articles/extensions-ai.md)
+- [Files & context caching](articles/files-and-caching.md)
+- [Migrating from v5 to v6](articles/migration-v5-to-v6.md)
+
+## API reference
+
+The full, generated [API reference](api/index.md) documents every public type and member.

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,0 +1,7 @@
+- name: Home
+  href: index.md
+- name: Guides
+  href: articles/
+  homepage: articles/getting-started.md
+- name: API Reference
+  href: api/

--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Junaid.GoogleGemini.Net.AspNetCoreSample.csproj
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Junaid.GoogleGemini.Net.AspNetCoreSample.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Junaid.GoogleGemini.Net\Junaid.GoogleGemini.Net.csproj" />
+    <ProjectReference Include="..\..\Junaid.GoogleGemini.Net.Extensions.AI\Junaid.GoogleGemini.Net.Extensions.AI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Program.cs
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Program.cs
@@ -1,0 +1,59 @@
+using System.Runtime.CompilerServices;
+using Junaid.GoogleGemini.Net.Extensions;
+using Junaid.GoogleGemini.Net.Extensions.AI;
+using Junaid.GoogleGemini.Net.Infrastructure.Telemetry;
+using Junaid.GoogleGemini.Net.Services.Interfaces;
+using Microsoft.Extensions.AI;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Trace;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// 1) Register Gemini from the "Gemini" config section.
+//    Provide the key via Gemini:ApiKey in appsettings, user-secrets, or the GeminiApiKey env var.
+builder.Services.AddGemini(builder.Configuration.GetSection("Gemini"));
+
+// 2) Also expose Gemini through the Microsoft.Extensions.AI IChatClient abstraction.
+builder.Services.AddGeminiChatClient("gemini-2.5-flash");
+
+// 3) Wire the library's OpenTelemetry traces + metrics to the console exporter so you can see
+//    per-call spans (model, token counts, finish reason) and the duration/token histograms.
+builder.Services.AddOpenTelemetry()
+    .WithTracing(tracing => tracing.AddSource(GeminiTelemetry.SourceName).AddConsoleExporter())
+    .WithMetrics(metrics => metrics.AddMeter(GeminiTelemetry.SourceName).AddConsoleExporter());
+
+var app = builder.Build();
+
+// Plain text generation:  GET /generate?prompt=Write%20a%20haiku
+app.MapGet("/generate", async (IGeminiService gemini, string prompt) =>
+    Results.Ok((await gemini.GenerateAsync(prompt)).Text()));
+
+// Typed structured output: GET /recipe?dish=pancakes  -> JSON shaped like Recipe
+app.MapGet("/recipe", async (IGeminiService gemini, string dish) =>
+    Results.Ok(await gemini.GenerateAsync<Recipe>($"A simple recipe for {dish}.")));
+
+// Streaming: GET /stream?prompt=...  -> chunks streamed as they arrive
+app.MapGet("/stream", (IGeminiService gemini, string prompt, CancellationToken ct)
+    => StreamText(gemini, prompt, ct));
+
+// Chat via Microsoft.Extensions.AI: POST /chat  { "message": "Hello" }
+app.MapPost("/chat", async (IChatClient chat, ChatRequest request) =>
+    Results.Ok((await chat.GetResponseAsync([new ChatMessage(ChatRole.User, request.Message)])).Text));
+
+app.Run();
+
+static async IAsyncEnumerable<string> StreamText(
+    IGeminiService gemini, string prompt, [EnumeratorCancellation] CancellationToken ct)
+{
+    await foreach (var chunk in gemini.StreamAsync(prompt, cancellationToken: ct))
+    {
+        var text = chunk.Text();
+        if (!string.IsNullOrEmpty(text))
+        {
+            yield return text;
+        }
+    }
+}
+
+internal record Recipe(string Title, string[] Ingredients, int Minutes);
+internal record ChatRequest(string Message);

--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/README.md
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/README.md
@@ -1,0 +1,27 @@
+# ASP.NET Core sample
+
+A minimal-API app showing how `Junaid.GoogleGemini.Net` is meant to be used in a real service:
+DI registration, text generation, **typed structured output**, **streaming**, the
+**`IChatClient`** abstraction, and **OpenTelemetry** wired to the console.
+
+## Run
+
+```shell
+# from the repo root
+setx GeminiApiKey "your-api-key"      # Windows; or: export GeminiApiKey=your-api-key
+dotnet run --project samples/Junaid.GoogleGemini.Net.AspNetCoreSample
+```
+
+(Or put the key in `appsettings.json` under `Gemini:ApiKey`, or use `dotnet user-secrets`.)
+
+## Endpoints
+
+| Method & route | What it shows |
+|---|---|
+| `GET /generate?prompt=...` | Basic text generation |
+| `GET /recipe?dish=pancakes` | `GenerateAsync<Recipe>` — typed JSON output |
+| `GET /stream?prompt=...` | Streaming chunks as they arrive |
+| `POST /chat` `{ "message": "..." }` | Chat via `Microsoft.Extensions.AI.IChatClient` |
+
+Watch the console while you hit an endpoint — you'll see the OpenTelemetry spans
+(`gen_ai.system`, `gen_ai.request.model`, token counts) and metrics the library emits.

--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/appsettings.json
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "Gemini": {
+    "ApiKey": "",
+    "DefaultModel": "gemini-2.5-flash",
+    "TimeoutSeconds": 30,
+    "MaxRetries": 3,
+    "RateLimit": {
+      "Enabled": true,
+      "RequestsPerMinute": 60
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the two remaining Phase 3 polish items: a runnable **ASP.NET Core sample** and a **DocFX documentation site** (guides + generated API reference).

## Sample — `samples/Junaid.GoogleGemini.Net.AspNetCoreSample`
A minimal-API app that demonstrates the library the way it's meant to be used:

| Route | Shows |
|---|---|
| `GET /generate` | text generation |
| `GET /recipe` | `GenerateAsync<T>` typed structured output |
| `GET /stream` | streaming via `IAsyncEnumerable` |
| `POST /chat` | `Microsoft.Extensions.AI.IChatClient` |

It also wires the library's **OpenTelemetry** traces + metrics to the console exporter. Verified it boots and resolves the full DI + telemetry graph.

## Docs — `docs/` (DocFX)
- Generated **API reference** from both packages' XML docs.
- Guides: getting started, structured output, streaming, resilience & rate limiting, observability, Microsoft.Extensions.AI, files & caching, and a **v5 → v6 migration** guide.
- Builds clean locally (`docfx`: 0 errors, 123 API metadata files). Generated output is gitignored.
- `.github/workflows/docs.yml` publishes to **GitHub Pages** on push to `master`.

## Notes / follow-ups
- To activate the docs site, set **repo Settings → Pages → Source = "GitHub Actions"** (one-time).
- The sample needs a real `GeminiApiKey` to make live calls.
- No library code changed; existing tests remain 25/25 green on net8.0 + net9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)