### PR TITLE
ci: publish both packages on release tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
             9.0.x
 
       - name: Pack
-        run: dotnet pack Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj -c Release -o ${{ github.workspace }}/artifacts
+        run: |
+          dotnet pack Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj -c Release -o ${{ github.workspace }}/artifacts
+          dotnet pack Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj -c Release -o ${{ github.workspace }}/artifacts
 
       - name: Push to NuGet
         # NUGET_API_KEY must be added under Settings → Secrets and variables → Actions.


### PR DESCRIPTION
The publish job only packed the core package. This packs Extensions.AI too so a `v*` tag publishes both (the wildcard `--skip-duplicate` push already handles multiple/duplicate packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)