### PR TITLE
test: opt-in live integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,27 @@
+name: Integration (live)
+
+# Live tests against the real Gemini API. MANUAL ONLY — run from the Actions tab.
+# Add a repo secret named GEMINI_API_KEY (Settings → Secrets and variables → Actions).
+# Without it, the tests self-skip (the run stays green).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  live:
+    name: Live integration tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+      - name: Run live integration tests
+        env:
+          # The library reads the key from the GeminiApiKey environment variable.
+          GeminiApiKey: ${{ secrets.GEMINI_API_KEY }}
+        run: dotnet test tests/Junaid.GoogleGemini.Net.IntegrationTests/Junaid.GoogleGemini.Net.IntegrationTests.csproj -c Release --verbosity normal

--- a/Junaid.GoogleGemini.Net.sln
+++ b/Junaid.GoogleGemini.Net.sln
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{5D20
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Junaid.GoogleGemini.Net.AspNetCoreSample", "samples\Junaid.GoogleGemini.Net.AspNetCoreSample\Junaid.GoogleGemini.Net.AspNetCoreSample.csproj", "{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Junaid.GoogleGemini.Net.IntegrationTests", "tests\Junaid.GoogleGemini.Net.IntegrationTests\Junaid.GoogleGemini.Net.IntegrationTests.csproj", "{B19E0514-80FD-419D-A70B-929E28C872F6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -87,6 +89,18 @@ Global
 		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|x64.Build.0 = Release|Any CPU
 		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|x86.ActiveCfg = Release|Any CPU
 		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC}.Release|x86.Build.0 = Release|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Debug|x64.Build.0 = Debug|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Debug|x86.Build.0 = Debug|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Release|x64.ActiveCfg = Release|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Release|x64.Build.0 = Release|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Release|x86.ActiveCfg = Release|Any CPU
+		{B19E0514-80FD-419D-A70B-929E28C872F6}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -94,6 +108,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{09EA83CD-C324-48D2-A41F-248C2E255110} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{A81ECD67-58AC-4B87-846D-CEC2AED3ACBC} = {5D20AA90-6969-D8BD-9DCD-8634F4692FDA}
+		{B19E0514-80FD-419D-A70B-929E28C872F6} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6CB5F522-7B50-4320-A3FC-C23F2BDA4550}

--- a/tests/Junaid.GoogleGemini.Net.IntegrationTests/Junaid.GoogleGemini.Net.IntegrationTests.csproj
+++ b/tests/Junaid.GoogleGemini.Net.IntegrationTests/Junaid.GoogleGemini.Net.IntegrationTests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Live integration tests against the real Gemini API. These are OPT-IN: every test is marked
+    [RequiresGeminiKey] and self-skips unless the GeminiApiKey environment variable is set. So this
+    project is safe to keep in the solution — normal `dotnet test` runs simply skip these.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Junaid.GoogleGemini.Net\Junaid.GoogleGemini.Net.csproj" />
+    <ProjectReference Include="..\..\Junaid.GoogleGemini.Net.Extensions.AI\Junaid.GoogleGemini.Net.Extensions.AI.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Junaid.GoogleGemini.Net.IntegrationTests/LiveTestInfrastructure.cs
+++ b/tests/Junaid.GoogleGemini.Net.IntegrationTests/LiveTestInfrastructure.cs
@@ -1,0 +1,56 @@
+using Junaid.GoogleGemini.Net.Extensions;
+using Junaid.GoogleGemini.Net.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Junaid.GoogleGemini.Net.IntegrationTests;
+
+/// <summary>
+/// A <see cref="FactAttribute"/> that skips the test unless the <c>GeminiApiKey</c> environment
+/// variable is set. Keeps the live suite opt-in so it never breaks ordinary CI runs.
+/// </summary>
+public sealed class RequiresGeminiKeyAttribute : FactAttribute
+{
+    public RequiresGeminiKeyAttribute()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("GeminiApiKey")))
+        {
+            Skip = "Set the GeminiApiKey environment variable to run live integration tests.";
+        }
+    }
+}
+
+/// <summary>
+/// Builds a real DI container once for the whole suite (reading the key from the environment), the
+/// same way a consuming app would. Constructing this does not call the API or validate the key —
+/// validation happens lazily on first use, which only occurs when a test actually runs.
+/// </summary>
+public sealed class GeminiFixture
+{
+    public IServiceProvider Services { get; }
+
+    public GeminiFixture()
+    {
+        var key = Environment.GetEnvironmentVariable("GeminiApiKey");
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddGemini(options =>
+        {
+            // A valid-format placeholder so the container builds even when tests will be skipped.
+            options.ApiKey = string.IsNullOrWhiteSpace(key) ? "AIzaSyPLACEHOLDER0123456789ABCDEFGHIJK" : key;
+            options.DefaultModel = "gemini-2.5-flash";
+        });
+        services.AddGeminiChatClient("gemini-2.5-flash");
+        services.AddGeminiEmbeddingGenerator("gemini-embedding-001");
+
+        Services = services.BuildServiceProvider();
+    }
+
+    public T Get<T>() where T : notnull => Services.GetRequiredService<T>();
+}
+
+/// <summary>Groups all live tests into one collection so they share the fixture and run sequentially
+/// (gentle on rate limits, deterministic ordering).</summary>
+[CollectionDefinition("Live")]
+public sealed class LiveCollection : ICollectionFixture<GeminiFixture>;

--- a/tests/Junaid.GoogleGemini.Net.IntegrationTests/LiveTests.cs
+++ b/tests/Junaid.GoogleGemini.Net.IntegrationTests/LiveTests.cs
@@ -1,0 +1,99 @@
+using Junaid.GoogleGemini.Net.Exceptions;
+using Junaid.GoogleGemini.Net.Services.Interfaces;
+using Microsoft.Extensions.AI;
+using Xunit;
+
+namespace Junaid.GoogleGemini.Net.IntegrationTests;
+
+/// <summary>
+/// Live tests against the real Gemini API. Assertions check structure/contract (non-empty output,
+/// token counts, types, status codes) rather than exact text, since model output is non-deterministic.
+/// All tests skip unless GeminiApiKey is set. Uses gemini-2.5-flash to keep cost/latency low.
+/// </summary>
+[Collection("Live")]
+public class LiveTests(GeminiFixture fixture)
+{
+    private IGeminiService Gemini => fixture.Get<IGeminiService>();
+
+    [RequiresGeminiKey]
+    public async Task GenerateAsync_ReturnsText()
+    {
+        var response = await Gemini.GenerateAsync("Reply with exactly the word: pong");
+
+        Assert.False(string.IsNullOrWhiteSpace(response.Text()));
+        Assert.Equal("STOP", response.FinishReason);
+        Assert.True(response.Usage?.TotalTokenCount > 0);
+    }
+
+    [RequiresGeminiKey]
+    public async Task GenerateAsyncT_ReturnsTypedObject()
+    {
+        var book = await Gemini.GenerateAsync<Book>("Return one well-known classic novel.");
+
+        Assert.False(string.IsNullOrWhiteSpace(book.Title));
+        Assert.False(string.IsNullOrWhiteSpace(book.Author));
+    }
+
+    [RequiresGeminiKey]
+    public async Task StreamAsync_YieldsChunks()
+    {
+        var chunks = new List<string>();
+        await foreach (var chunk in Gemini.StreamAsync("Count from 1 to 5, one number per line."))
+        {
+            chunks.Add(chunk.Text());
+        }
+
+        Assert.NotEmpty(chunks);
+        Assert.False(string.IsNullOrWhiteSpace(string.Concat(chunks)));
+    }
+
+    [RequiresGeminiKey]
+    public async Task CountTokensAsync_ReturnsPositive()
+    {
+        var tokens = await Gemini.CountTokensAsync("Hello, world.");
+
+        Assert.True(tokens.TotalTokens > 0);
+    }
+
+    [RequiresGeminiKey]
+    public async Task EmbedContent_ReturnsVector()
+    {
+        var embeddings = fixture.Get<IEmbeddingService>();
+
+        var result = await embeddings.EmbedContentAsync("gemini-embedding-001", "semantic search text");
+
+        Assert.NotNull(result.Embedding?.Values);
+        Assert.True(result.Embedding!.Values!.Length > 0);
+    }
+
+    [RequiresGeminiKey]
+    public async Task ListModels_ReturnsModels()
+    {
+        var models = await fixture.Get<IModelInfoService>().ListModelsAsync();
+
+        Assert.NotEmpty(models.Models);
+    }
+
+    [RequiresGeminiKey]
+    public async Task GetModel_Unknown_ThrowsApiException()
+    {
+        // Passes client-side validation (length only), so this reaches the API and returns a 4xx —
+        // verifying our error mapping against the real service.
+        var ex = await Assert.ThrowsAsync<GeminiApiException>(
+            () => fixture.Get<IModelInfoService>().GetModelAsync("gemini-does-not-exist-9999"));
+
+        Assert.True((int)ex.StatusCode >= 400);
+    }
+
+    [RequiresGeminiKey]
+    public async Task ChatClient_GetResponseAsync_ReturnsText()
+    {
+        var chat = fixture.Get<IChatClient>();
+
+        var response = await chat.GetResponseAsync([new ChatMessage(ChatRole.User, "Reply with: hi")]);
+
+        Assert.False(string.IsNullOrWhiteSpace(response.Text));
+    }
+
+    private sealed record Book(string Title, string Author, int Year);
+}


### PR DESCRIPTION
Adds a path off alpha: live tests against the real Gemini API.

- **Opt-in**: `[RequiresGeminiKey]` self-skips unless `GeminiApiKey` is set, so normal CI and contributors without a key are unaffected (8 tests skip, run stays green).
- **Coverage** (core scope): text generation, `GenerateAsync<T>`, streaming, token counting, embeddings, model listing, `IChatClient`, and real-API error mapping (404 → `GeminiApiException`). Structural assertions only; `gemini-2.5-flash` to keep cost low.
- **CI**: `integration.yml` runs them **manually** (`workflow_dispatch`) via a `GEMINI_API_KEY` secret.

Verified locally: 8 tests skip without a key; unit tests remain 25/25 on net8/net9.

To run them: add repo secret `GEMINI_API_KEY`, then trigger the *Integration (live)* workflow (or set `GeminiApiKey` locally and `dotnet test` the project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)