### PR TITLE
feat: Gemini 3 support + correctness (beta.2)

### DIFF
--- a/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
+++ b/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
@@ -11,7 +11,7 @@
 		<Description>Microsoft.Extensions.AI adapters (IChatClient, IEmbeddingGenerator) for Junaid.GoogleGemini.Net — use Google Gemini anywhere the .NET AI abstractions are consumed. Built with AI: implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;Microsoft.Extensions.AI;IChatClient;AI;LLM;dotnet</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-beta.1</Version>
+		<Version>6.0.0-beta.2</Version>
 
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Junaid.GoogleGemini.Net/Infrastructure/Factories/RequestFactory.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/Factories/RequestFactory.cs
@@ -98,13 +98,34 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Factories
         }
 
         /// <summary>
+        /// Builds a request directly from a list of <see cref="Content"/> items. Use this for full
+        /// multi-turn control — echoing back response parts (function calls, function responses, and
+        /// Gemini 3 thought signatures) that the simpler text-based chat helpers can't represent.
+        /// </summary>
+        public static GenerateContentRequest CreateRequest(IEnumerable<Content> contents, GeminiRequestOptions? options = null)
+        {
+            return new GenerateContentRequest
+            {
+                Contents = contents.ToList(),
+                GenerationConfig = CreateGenerationConfig(options),
+                SystemInstruction = BuildSystemInstruction(options),
+                Tools = BuildTools(options),
+                ToolConfig = options?.ToolConfig,
+                CachedContent = options?.CachedContent,
+                SafetySettings = options?.SafetySettings ?? GetDefaultSafetySettings()
+            };
+        }
+
+        /// <summary>
         /// Creates generation config from options
         /// </summary>
         private static GenerationConfig CreateGenerationConfig(GeminiRequestOptions? options)
         {
+            // No options: send an empty config so the model uses its native defaults (notably
+            // temperature 1.0 on Gemini 3, which advises against forcing a lower value).
             if (options == null)
             {
-                return new GenerationConfig { Temperature = GeminiConstants.Defaults.Temperature };
+                return new GenerationConfig();
             }
 
             return new GenerationConfig
@@ -118,6 +139,7 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Factories
                 Seed = options.Seed,
                 ResponseMimeType = options.ResponseMimeType,
                 ResponseSchema = options.ResponseSchema,
+                MediaResolution = options.MediaResolution,
                 ThinkingConfig = BuildThinkingConfig(options)
             };
         }
@@ -177,14 +199,23 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Factories
         /// <summary>Builds a thinking config from options, or null when neither thinking option is set.</summary>
         private static ThinkingConfig? BuildThinkingConfig(GeminiRequestOptions options)
         {
-            if (options.ThinkingBudget is null && options.IncludeThoughts is null)
+            if (options.ThinkingBudget is null && options.ThinkingLevel is null && options.IncludeThoughts is null)
             {
                 return null;
+            }
+
+            // The API rejects requests that set both; fail fast with a clear message.
+            if (options.ThinkingBudget is not null && options.ThinkingLevel is not null)
+            {
+                throw new ArgumentException(
+                    "Set only one of ThinkingBudget (Gemini 2.5) or ThinkingLevel (Gemini 3+), not both.",
+                    nameof(options));
             }
 
             return new ThinkingConfig
             {
                 ThinkingBudget = options.ThinkingBudget,
+                ThinkingLevel = options.ThinkingLevel,
                 IncludeThoughts = options.IncludeThoughts
             };
         }

--- a/Junaid.GoogleGemini.Net/Infrastructure/Options/GeminiOptions.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/Options/GeminiOptions.cs
@@ -42,7 +42,7 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Options
         /// <summary>
         /// Default model to use for requests
         /// </summary>
-        public string DefaultModel { get; set; } = GeminiConstants.Models.Gemini25Pro;
+        public string DefaultModel { get; set; } = GeminiConstants.Defaults.Model;
 
         /// <summary>
         /// Rate limiting settings

--- a/Junaid.GoogleGemini.Net/Infrastructure/Utilities/GeminiConstants.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/Utilities/GeminiConstants.cs
@@ -32,49 +32,60 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Utilities
         /// </summary>
         public static class Models
         {
+            // Gemini 3 family (current). These names are informational; model names are not validated
+            // against any allow-list, so newer models work without a library update.
+            /// <summary>GA, most intelligent flash model for sustained frontier performance.</summary>
+            public const string Gemini35Flash = "gemini-3.5-flash";
+            public const string Gemini31Pro = "gemini-3.1-pro-preview";
+            public const string Gemini3Flash = "gemini-3-flash-preview";
+            /// <summary>GA, cost-efficient for high volume.</summary>
+            public const string Gemini31FlashLite = "gemini-3.1-flash-lite";
+            /// <summary>Highest-quality native image generation (Nano Banana).</summary>
+            public const string Gemini3ProImage = "gemini-3-pro-image-preview";
+            /// <summary>High-efficiency native image generation (Nano Banana).</summary>
+            public const string Gemini31FlashImage = "gemini-3.1-flash-image-preview";
+
+            // Gemini 2.x (still available).
             public const string Gemini25Pro = "gemini-2.5-pro";
             public const string Gemini25Flash = "gemini-2.5-flash";
-            public const string Gemini20Flash = "gemini-2.0-flash-001";
             public const string Gemini15Pro = "gemini-1.5-pro";
             public const string Gemini15Flash = "gemini-1.5-flash";
-
             public const string GeminiPro = "gemini-pro";
             public const string Gemini10Pro = "gemini-1.0-pro";
+
+            // Embeddings.
             public const string Embedding001 = "embedding-001";
             public const string TextEmbedding004 = "text-embedding-004";
-
-            /// <summary>The current general-purpose embedding model.</summary>
+            /// <summary>General-purpose text embedding model.</summary>
             public const string GeminiEmbedding001 = "gemini-embedding-001";
+            /// <summary>Multimodal embedding model (text, image, video, audio, PDF).</summary>
+            public const string GeminiEmbedding2 = "gemini-embedding-2";
 
+            /// <summary>A non-exhaustive list of common content-generation models (informational).</summary>
             public static readonly string[] ContentGenerationModels =
             {
+                Gemini35Flash,
+                Gemini31Pro,
+                Gemini3Flash,
+                Gemini31FlashLite,
                 Gemini25Pro,
-                Gemini25Flash,
-                Gemini20Flash,
-                Gemini15Pro,
-                Gemini15Flash,
-                GeminiPro,
-                Gemini10Pro
+                Gemini25Flash
             };
 
+            /// <summary>A non-exhaustive list of common embedding models (informational).</summary>
             public static readonly string[] EmbeddingModels =
             {
+                GeminiEmbedding2,
                 GeminiEmbedding001,
                 TextEmbedding004,
                 Embedding001
             };
 
-            public static readonly string[] MultimodalModels =
-            {
-                Gemini25Pro,
-                Gemini25Flash,
-                Gemini20Flash,
-                Gemini15Pro,
-                Gemini15Flash
-            };
+            /// <summary>The recommended general-purpose model (GA).</summary>
+            public static string Recommended => Gemini35Flash;
 
-            public static string Recommended => Gemini25Pro;
-            public static string Fastest => Gemini25Flash;
+            /// <summary>The fastest / most cost-efficient model (GA).</summary>
+            public static string Fastest => Gemini31FlashLite;
         }
 
         #endregion Model Information
@@ -266,11 +277,37 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Utilities
             public const float Temperature = 0.7f;
 
             /// <summary>
-            /// Default model for new requests
+            /// Default model for new requests (a current GA model).
             /// </summary>
-            public const string Model = Models.Gemini25Pro;
+            public const string Model = Models.Gemini35Flash;
         }
 
         #endregion Default Values
+
+        #region Reasoning & Media
+
+        /// <summary>
+        /// Thinking levels for Gemini 3+ (<c>thinkingConfig.thinkingLevel</c>). Controls reasoning depth.
+        /// </summary>
+        public static class ThinkingLevels
+        {
+            public const string Minimal = "minimal";
+            public const string Low = "low";
+            public const string Medium = "medium";
+            public const string High = "high";
+        }
+
+        /// <summary>
+        /// Media resolution settings for image/video/PDF parts (Gemini 3+).
+        /// </summary>
+        public static class MediaResolutions
+        {
+            public const string Low = "media_resolution_low";
+            public const string Medium = "media_resolution_medium";
+            public const string High = "media_resolution_high";
+            public const string UltraHigh = "media_resolution_ultra_high";
+        }
+
+        #endregion Reasoning & Media
     }
 }

--- a/Junaid.GoogleGemini.Net/Infrastructure/Utilities/ValidationUtilities.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/Utilities/ValidationUtilities.cs
@@ -13,10 +13,6 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Utilities
         /// <summary>
         /// Cached array of all valid models (content generation + embedding models) to avoid repeated allocations
         /// </summary>
-        private static readonly string[] _allValidModels = GeminiConstants.Models.ContentGenerationModels
-            .Concat(GeminiConstants.Models.EmbeddingModels)
-            .ToArray();
-
         /// <summary>
         /// Cached array of valid message roles to avoid repeated allocations
         /// </summary>
@@ -220,16 +216,12 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Utilities
         /// <exception cref="ArgumentException">Thrown for invalid model names</exception>
         public static void ValidateModelName(string? modelName, string paramName = "model")
         {
+            // We deliberately do NOT validate against a hardcoded allow-list: Google ships new models
+            // frequently (e.g. the Gemini 3 family), and an allow-list would reject them client-side.
+            // We only check the name is present; the API authoritatively rejects unknown models.
             if (string.IsNullOrWhiteSpace(modelName))
             {
                 throw new ArgumentException("Model name cannot be null or empty", paramName);
-            }
-
-            if (!_allValidModels.Contains(modelName))
-            {
-                throw new ArgumentException(
-                    $"Invalid model '{modelName}'. Valid models are: {string.Join(", ", _allValidModels)}",
-                    paramName);
             }
         }
 
@@ -241,16 +233,11 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Utilities
         /// <exception cref="ArgumentException">Thrown for invalid model names</exception>
         public static void ValidateEmbeddingModel(string? modelName, string paramName = "model")
         {
+            // No allow-list (see ValidateModelName) — new embedding models (e.g. gemini-embedding-2)
+            // must work without a library update.
             if (string.IsNullOrWhiteSpace(modelName))
             {
                 throw new ArgumentException("Model name cannot be null or empty", paramName);
-            }
-
-            if (!GeminiConstants.Models.EmbeddingModels.Contains(modelName))
-            {
-                throw new ArgumentException(
-                    $"Invalid embedding model '{modelName}'. Valid models are: {string.Join(", ", GeminiConstants.Models.EmbeddingModels)}",
-                    paramName);
             }
         }
 

--- a/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
+++ b/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
@@ -19,8 +19,16 @@
 		<Description>A production-ready .NET client for the Google Gemini API: resilient (retries + rate limiting), observable, and DI-native, with first-class ASP.NET Core ergonomics. Built with AI: the v6 modernization was implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;GenerativeAI;AI;LLM;GoogleAI;dotnet;aspnetcore;IChatClient</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-beta.1</Version>
+		<Version>6.0.0-beta.2</Version>
 		<PackageReleaseNotes>
+			6.0 beta.2: Gemini 3 support and correctness.
+			- Models are no longer validated against a hardcoded allow-list, so Gemini 3.x (and any future
+			  model) work without a library update; added Gemini 3 model constants and made a current GA
+			  model the default.
+			- thinkingLevel (Gemini 3) alongside thinkingBudget (mutually exclusive, guarded); mediaResolution;
+			  thoughtSignature captured on response parts and echoable via a new Content-based ChatAsync/
+			  StreamChatAsync overload (required for Gemini 3 multi-turn function calling).
+			- No longer forces a default temperature, per Gemini 3 guidance to keep it at the model default.
 			6.0 beta.1: the core surface is now validated end-to-end against the live Gemini API
 			(text, structured output, streaming, embeddings, token counting, model listing, IChatClient,
 			and error mapping). Feature-complete and validated; still a prerelease while extended

--- a/Junaid.GoogleGemini.Net/Models/GoogleApi/GenerationConfig.cs
+++ b/Junaid.GoogleGemini.Net/Models/GoogleApi/GenerationConfig.cs
@@ -61,17 +61,31 @@ public class GenerationConfig
     /// <summary>Configures model "thinking"/reasoning (Gemini 2.5+).</summary>
     [JsonPropertyName("thinkingConfig")]
     public ThinkingConfig? ThinkingConfig { get; set; }
+
+    /// <summary>
+    /// Default media resolution for image/video/PDF parts (Gemini 3+). One of the
+    /// <c>GeminiConstants.MediaResolutions</c> values; can also be set per-part.
+    /// </summary>
+    [JsonPropertyName("mediaResolution")]
+    public string? MediaResolution { get; set; }
 }
 
 /// <summary>Configures the model's internal reasoning budget (Gemini 2.5+ "thinking").</summary>
 public class ThinkingConfig
 {
     /// <summary>
-    /// Reasoning token budget. <c>0</c> disables thinking (where allowed); <c>-1</c> lets the model
-    /// decide dynamically.
+    /// Reasoning token budget (Gemini 2.5). <c>0</c> disables thinking (where allowed); <c>-1</c> lets
+    /// the model decide. Mutually exclusive with <see cref="ThinkingLevel"/>.
     /// </summary>
     [JsonPropertyName("thinkingBudget")]
     public int? ThinkingBudget { get; set; }
+
+    /// <summary>
+    /// Reasoning depth (Gemini 3+): one of the <c>GeminiConstants.ThinkingLevels</c> values
+    /// ("minimal"/"low"/"medium"/"high"). Mutually exclusive with <see cref="ThinkingBudget"/>.
+    /// </summary>
+    [JsonPropertyName("thinkingLevel")]
+    public string? ThinkingLevel { get; set; }
 
     /// <summary>When true, thought-summary parts are included in the response.</summary>
     [JsonPropertyName("includeThoughts")]

--- a/Junaid.GoogleGemini.Net/Models/GoogleApi/Part.cs
+++ b/Junaid.GoogleGemini.Net/Models/GoogleApi/Part.cs
@@ -31,6 +31,14 @@ public class Part
     /// <summary>True when this part is a thought summary (only present when thoughts are included).</summary>
     [JsonPropertyName("thought")]
     public bool? Thought { get; set; }
+
+    /// <summary>
+    /// Encrypted "thought signature" (Gemini 3+). The API returns it on response parts and requires
+    /// it to be echoed back in follow-up turns — for function calling, a missing signature causes a
+    /// 400. Preserve the response parts (and this value) when building multi-turn history.
+    /// </summary>
+    [JsonPropertyName("thoughtSignature")]
+    public string? ThoughtSignature { get; set; }
 }
 
 /// <summary>References a file uploaded via the Files API.</summary>

--- a/Junaid.GoogleGemini.Net/Models/Requests/GeminiRequestOptions.cs
+++ b/Junaid.GoogleGemini.Net/Models/Requests/GeminiRequestOptions.cs
@@ -59,10 +59,19 @@ namespace Junaid.GoogleGemini.Net.Models.Requests
         public JsonNode? ResponseSchema { get; set; }
 
         /// <summary>
-        /// Thinking/reasoning token budget (Gemini 2.5+). <c>0</c> disables thinking where allowed;
-        /// <c>-1</c> lets the model decide.
+        /// Thinking/reasoning token budget (Gemini 2.5). <c>0</c> disables thinking where allowed;
+        /// <c>-1</c> lets the model decide. Mutually exclusive with <see cref="ThinkingLevel"/>.
         /// </summary>
         public int? ThinkingBudget { get; set; }
+
+        /// <summary>
+        /// Reasoning depth for Gemini 3+ (see <c>GeminiConstants.ThinkingLevels</c>): "minimal", "low",
+        /// "medium", or "high". Mutually exclusive with <see cref="ThinkingBudget"/>.
+        /// </summary>
+        public string? ThinkingLevel { get; set; }
+
+        /// <summary>Media resolution for image/video/PDF parts (see <c>GeminiConstants.MediaResolutions</c>).</summary>
+        public string? MediaResolution { get; set; }
 
         /// <summary>When true, includes thought-summary parts in the response.</summary>
         public bool? IncludeThoughts { get; set; }
@@ -144,7 +153,8 @@ namespace Junaid.GoogleGemini.Net.Models.Requests
         /// </summary>
         public static GeminiRequestOptions Default(string? model = null) => new()
         {
-            Temperature = GeminiConstants.Defaults.Temperature,
+            // No explicit temperature: let the model use its native default (1.0 on Gemini 3, which
+            // recommends against lowering it).
             Model = model ?? GeminiConstants.Models.Recommended
         };
 
@@ -153,7 +163,6 @@ namespace Junaid.GoogleGemini.Net.Models.Requests
         /// </summary>
         public static GeminiRequestOptions Fast() => new()
         {
-            Temperature = GeminiConstants.Defaults.Temperature,
             Model = GeminiConstants.Models.Fastest
         };
 
@@ -162,7 +171,7 @@ namespace Junaid.GoogleGemini.Net.Models.Requests
         /// </summary>
         /// <param name="model">The specific model to use</param>
         /// <param name="temperature">Optional temperature setting</param>
-        public static GeminiRequestOptions WithModel(string model, float? temperature = 0.7f) => new()
+        public static GeminiRequestOptions WithModel(string model, float? temperature = null) => new()
         {
             Model = model,
             Temperature = temperature
@@ -193,6 +202,8 @@ namespace Junaid.GoogleGemini.Net.Models.Requests
             ResponseMimeType = ResponseMimeType,
             ResponseSchema = ResponseSchema,
             ThinkingBudget = ThinkingBudget,
+            ThinkingLevel = ThinkingLevel,
+            MediaResolution = MediaResolution,
             IncludeThoughts = IncludeThoughts,
             Seed = Seed,
             CandidateCount = CandidateCount,

--- a/Junaid.GoogleGemini.Net/Services/EmbeddingService.cs
+++ b/Junaid.GoogleGemini.Net/Services/EmbeddingService.cs
@@ -18,8 +18,6 @@ namespace Junaid.GoogleGemini.Net.Services
         private const int MAX_TEXT_LENGTH = 20000;
         private const int MAX_BATCH_SIZE = 100;
 
-        private static readonly string[] ValidModels = GeminiConstants.Models.EmbeddingModels;
-
         /// <summary>
         /// Initializes a new instance of the EmbeddingService
         /// </summary>
@@ -149,16 +147,11 @@ namespace Junaid.GoogleGemini.Net.Services
 
         private static void ValidateModel(string model)
         {
+            // No allow-list: new embedding models (e.g. gemini-embedding-2) must work without a
+            // library update. The API rejects genuinely invalid names.
             if (string.IsNullOrWhiteSpace(model))
             {
                 throw new ArgumentException("Model name cannot be null or empty", nameof(model));
-            }
-
-            if (!ValidModels.Contains(model))
-            {
-                throw new ArgumentException(
-                    $"Invalid model '{model}'. Supported models: {string.Join(", ", ValidModels)}",
-                    nameof(model));
             }
         }
 

--- a/Junaid.GoogleGemini.Net/Services/GeminiService.cs
+++ b/Junaid.GoogleGemini.Net/Services/GeminiService.cs
@@ -113,6 +113,48 @@ namespace Junaid.GoogleGemini.Net.Services
         }
 
         /// <inheritdoc/>
+        public async Task<GenerateContentResponse> ChatAsync(
+            IList<Content> contents,
+            GeminiRequestOptions? options = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (contents is null || contents.Count == 0)
+            {
+                throw new ArgumentException("At least one content item is required.", nameof(contents));
+            }
+
+            var request = RequestFactory.CreateRequest(contents, options);
+            var endpoint = GetGenerateEndpoint(options?.Model);
+
+            return await ExecuteRequestAsync<GenerateContentRequest, GenerateContentResponse>(
+                "chat generation",
+                endpoint,
+                request,
+                new { MessageCount = contents.Count },
+                cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async IAsyncEnumerable<GenerateContentResponse> StreamChatAsync(
+            IList<Content> contents,
+            GeminiRequestOptions? options = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            if (contents is null || contents.Count == 0)
+            {
+                throw new ArgumentException("At least one content item is required.", nameof(contents));
+            }
+
+            var request = RequestFactory.CreateRequest(contents, options);
+            var endpoint = GetStreamEndpoint(options?.Model);
+
+            await foreach (var chunk in StreamRequestAsync(endpoint, request, cancellationToken))
+            {
+                yield return chunk;
+            }
+        }
+
+        /// <inheritdoc/>
         public async IAsyncEnumerable<GenerateContentResponse> StreamAsync(
             string prompt,
             GeminiRequestOptions? options = null,

--- a/Junaid.GoogleGemini.Net/Services/Interfaces/IGeminiService.cs
+++ b/Junaid.GoogleGemini.Net/Services/Interfaces/IGeminiService.cs
@@ -58,6 +58,23 @@ namespace Junaid.GoogleGemini.Net.Services.Interfaces
             CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Generates content from a raw list of <see cref="Content"/> turns. Use this for full
+        /// multi-turn control — including echoing back the model's previous response parts (function
+        /// calls/responses and Gemini 3 <c>thoughtSignature</c> values), which the simple text-based
+        /// <see cref="ChatAsync(MessageObject[], GeminiRequestOptions?, CancellationToken)"/> can't carry.
+        /// </summary>
+        Task<GenerateContentResponse> ChatAsync(
+            IList<Content> contents,
+            GeminiRequestOptions? options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>Streaming counterpart of <see cref="ChatAsync(IList{Content}, GeminiRequestOptions?, CancellationToken)"/>.</summary>
+        IAsyncEnumerable<GenerateContentResponse> StreamChatAsync(
+            IList<Content> contents,
+            GeminiRequestOptions? options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Streams content generation for a text prompt, yielding each response chunk as it arrives.
         /// Iterate with <c>await foreach</c>; use <c>chunk.Text()</c> for the text of each chunk.
         /// </summary>

--- a/tests/Junaid.GoogleGemini.Net.Tests/Gemini3SupportTests.cs
+++ b/tests/Junaid.GoogleGemini.Net.Tests/Gemini3SupportTests.cs
@@ -1,0 +1,133 @@
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Junaid.GoogleGemini.Net.Infrastructure;
+using Junaid.GoogleGemini.Net.Infrastructure.Factories;
+using Junaid.GoogleGemini.Net.Infrastructure.Options;
+using Junaid.GoogleGemini.Net.Infrastructure.Serialization;
+using Junaid.GoogleGemini.Net.Infrastructure.Utilities;
+using Junaid.GoogleGemini.Net.Models.GoogleApi;
+using Junaid.GoogleGemini.Net.Models.Requests;
+using Junaid.GoogleGemini.Net.Services;
+using Junaid.GoogleGemini.Net.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Junaid.GoogleGemini.Net.Tests;
+
+public class Gemini3SupportTests
+{
+    [Fact]
+    public void ValidateModelName_AcceptsUnknownModels()
+    {
+        // Must not throw for a Gemini 3 model the library has never heard of.
+        ValidationUtilities.ValidateModelName("gemini-3.1-pro-preview");
+        ValidationUtilities.ValidateEmbeddingModel("gemini-embedding-2");
+    }
+
+    [Fact]
+    public void ValidateModelName_RejectsEmpty()
+    {
+        Assert.Throws<ArgumentException>(() => ValidationUtilities.ValidateModelName("  "));
+    }
+
+    [Fact]
+    public void RequestFactory_NoOptions_OmitsTemperature()
+    {
+        var request = RequestFactory.CreateTextRequest("hi", options: null);
+        var json = JsonSerializer.Serialize(request, GeminiJson.Default);
+
+        // No forced default — let the model use its native temperature (1.0 on Gemini 3).
+        Assert.DoesNotContain("temperature", json, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ThinkingLevel_Serializes()
+    {
+        var request = RequestFactory.CreateTextRequest("hi",
+            new GeminiRequestOptions { ThinkingLevel = GeminiConstants.ThinkingLevels.High });
+        var json = JsonSerializer.Serialize(request, GeminiJson.Default);
+
+        Assert.Contains("\"thinkingLevel\":\"high\"", json);
+    }
+
+    [Fact]
+    public void SettingBothThinkingBudgetAndLevel_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => RequestFactory.CreateTextRequest("hi",
+            new GeminiRequestOptions { ThinkingBudget = 256, ThinkingLevel = "high" }));
+    }
+
+    [Fact]
+    public void MediaResolution_Serializes()
+    {
+        var request = RequestFactory.CreateTextRequest("hi",
+            new GeminiRequestOptions { MediaResolution = GeminiConstants.MediaResolutions.High });
+        var json = JsonSerializer.Serialize(request, GeminiJson.Default);
+
+        Assert.Contains("\"mediaResolution\":\"media_resolution_high\"", json);
+    }
+
+    [Fact]
+    public void ThoughtSignature_RoundTrips()
+    {
+        const string responseJson =
+            """{"candidates":[{"content":{"role":"model","parts":[{"functionCall":{"name":"f","args":{}},"thoughtSignature":"sig-123"}]}}]}""";
+
+        var response = JsonSerializer.Deserialize<GenerateContentResponse>(responseJson, GeminiJson.Default)!;
+        var part = response.Candidates![0].Content!.Parts[0];
+        Assert.Equal("sig-123", part.ThoughtSignature);
+
+        // And it serializes back out when echoed into a follow-up request.
+        var roundTripped = JsonSerializer.Serialize(response.Candidates[0].Content, GeminiJson.Default);
+        Assert.Contains("\"thoughtSignature\":\"sig-123\"", roundTripped);
+    }
+
+    [Fact]
+    public async Task ChatAsync_ContentOverload_SendsPartsVerbatim()
+    {
+        const string ok =
+            """{"candidates":[{"content":{"role":"model","parts":[{"text":"done"}]},"finishReason":"STOP"}]}""";
+        var handler = FakeHttpMessageHandler.RespondWith(HttpStatusCode.OK, ok);
+        var service = CreateService(handler);
+
+        var contents = new List<Content>
+        {
+            new() { Role = "user", Parts = [new Part { Text = "weather?" }] },
+            new()
+            {
+                Role = "model",
+                Parts =
+                [
+                    new Part
+                    {
+                        FunctionCall = new FunctionCallPart { Name = "get_weather", Args = JsonNode.Parse("{\"city\":\"Paris\"}") },
+                        ThoughtSignature = "sig-abc"
+                    }
+                ]
+            },
+            new()
+            {
+                Role = "user",
+                Parts = [new Part { FunctionResponse = new FunctionResponsePart { Name = "get_weather", Response = JsonNode.Parse("{\"tempC\":18}") } }]
+            },
+        };
+
+        var response = await service.ChatAsync(contents);
+
+        Assert.Equal("done", response.Text());
+        var body = handler.RequestBodies[0]!;
+        Assert.Contains("\"thoughtSignature\":\"sig-abc\"", body); // signature echoed back
+        Assert.Contains("\"functionResponse\"", body);
+        Assert.Contains("get_weather", body);
+    }
+
+    private static GeminiService CreateService(FakeHttpMessageHandler handler)
+    {
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.test/v1beta/") };
+        var client = new GeminiClient(httpClient, NullLogger<GeminiClient>.Instance, GeminiRateLimiter.CreateDisabled());
+        var options = Options.Create(new GeminiOptions { ApiKey = "AIzaSyDUMMY_KEY_FOR_UNIT_TESTS_12345" });
+        return new GeminiService(client, NullLogger<GeminiService>.Instance, options, new SafetyService());
+    }
+}


### PR DESCRIPTION
Implements the critical batch from the changelog gap analysis so the library works correctly on current Gemini 3 models.

- **Model allow-list removed** — it was rejecting every Gemini 3 model client-side (and would fail `DefaultModel` validation at startup). Now validates non-empty only; the API authoritatively rejects bad names. Added Gemini 3 constants; default is now `gemini-3.5-flash` (GA).
- **`thinkingLevel`** (Gemini 3) + **`mediaResolution`**, with a guard against sending `thinkingBudget` and `thinkingLevel` together.
- **`thoughtSignature`** captured on `Part`; new **`Content`-based `ChatAsync`/`StreamChatAsync`** overloads so multi-turn function calling can echo signatures back (Gemini 3 returns 400 otherwise).
- **No forced default temperature** (Gemini 3 advises keeping it at the model default).

8 new tests; 33/33 green on net8.0 + net9.0. Bumped to `6.0.0-beta.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)