### PR TITLE
chore(sample): use Gemini 3 (gemini-3.5-flash)

### DIFF
--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Program.cs
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Program.cs
@@ -2,6 +2,7 @@ using System.Runtime.CompilerServices;
 using Junaid.GoogleGemini.Net.Extensions;
 using Junaid.GoogleGemini.Net.Extensions.AI;
 using Junaid.GoogleGemini.Net.Infrastructure.Telemetry;
+using Junaid.GoogleGemini.Net.Infrastructure.Utilities;
 using Junaid.GoogleGemini.Net.Services.Interfaces;
 using Microsoft.Extensions.AI;
 using OpenTelemetry.Metrics;
@@ -14,7 +15,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddGemini(builder.Configuration.GetSection("Gemini"));
 
 // 2) Also expose Gemini through the Microsoft.Extensions.AI IChatClient abstraction.
-builder.Services.AddGeminiChatClient("gemini-2.5-flash");
+builder.Services.AddGeminiChatClient(GeminiConstants.Models.Gemini35Flash);
 
 // 3) Wire the library's OpenTelemetry traces + metrics to the console exporter so you can see
 //    per-call spans (model, token counts, finish reason) and the duration/token histograms.

--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/appsettings.json
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/appsettings.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
   "Gemini": {
     "ApiKey": "",
-    "DefaultModel": "gemini-2.5-flash",
+    "DefaultModel": "gemini-3.5-flash",
     "TimeoutSeconds": 30,
     "MaxRetries": 3,
     "RateLimit": {


### PR DESCRIPTION
Updates the ASP.NET Core sample to a current Gemini 3 GA model (IChatClient + DefaultModel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)