### PR TITLE
feat: raise default timeout to 100s; sample uses low thinking (beta.3)

### DIFF
--- a/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
+++ b/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
@@ -11,7 +11,7 @@
 		<Description>Microsoft.Extensions.AI adapters (IChatClient, IEmbeddingGenerator) for Junaid.GoogleGemini.Net — use Google Gemini anywhere the .NET AI abstractions are consumed. Built with AI: implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;Microsoft.Extensions.AI;IChatClient;AI;LLM;dotnet</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-beta.2</Version>
+		<Version>6.0.0-beta.3</Version>
 
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Junaid.GoogleGemini.Net/Infrastructure/Options/GeminiOptions.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/Options/GeminiOptions.cs
@@ -25,7 +25,7 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Options
         /// Default timeout for API requests in seconds
         /// </summary>
         [Range(1, 300)]
-        public int TimeoutSeconds { get; set; } = 30;
+        public int TimeoutSeconds { get; set; } = GeminiConstants.Defaults.TimeoutSeconds;
 
         /// <summary>
         /// Maximum number of retries for transient failures (HTTP 429, 5xx, network errors).

--- a/Junaid.GoogleGemini.Net/Infrastructure/Utilities/GeminiConstants.cs
+++ b/Junaid.GoogleGemini.Net/Infrastructure/Utilities/GeminiConstants.cs
@@ -262,9 +262,11 @@ namespace Junaid.GoogleGemini.Net.Infrastructure.Utilities
         public static class Defaults
         {
             /// <summary>
-            /// Default timeout in seconds
+            /// Default timeout in seconds. Generous by default because current models (Gemini 3
+            /// "thinking" models default to high reasoning depth) can take well over a minute on a
+            /// single call; a short timeout produces spurious GeminiTimeoutExceptions.
             /// </summary>
-            public const int TimeoutSeconds = 30;
+            public const int TimeoutSeconds = 100;
 
             /// <summary>
             /// Default maximum retries

--- a/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
+++ b/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
@@ -19,8 +19,12 @@
 		<Description>A production-ready .NET client for the Google Gemini API: resilient (retries + rate limiting), observable, and DI-native, with first-class ASP.NET Core ergonomics. Built with AI: the v6 modernization was implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;GenerativeAI;AI;LLM;GoogleAI;dotnet;aspnetcore;IChatClient</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-beta.2</Version>
+		<Version>6.0.0-beta.3</Version>
 		<PackageReleaseNotes>
+			6.0 beta.3: default request timeout raised from 30s to 100s. Gemini 3 "thinking" models
+			default to high reasoning depth and a single call can take well over a minute; the old
+			30s default caused spurious GeminiTimeoutExceptions. (Lower TimeoutSeconds, or set a lower
+			ThinkingLevel, for latency-sensitive workloads.)
 			6.0 beta.2: Gemini 3 support and correctness.
 			- Models are no longer validated against a hardcoded allow-list, so Gemini 3.x (and any future
 			  model) work without a library update; added Gemini 3 model constants and made a current GA

--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Program.cs
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/Program.cs
@@ -3,6 +3,7 @@ using Junaid.GoogleGemini.Net.Extensions;
 using Junaid.GoogleGemini.Net.Extensions.AI;
 using Junaid.GoogleGemini.Net.Infrastructure.Telemetry;
 using Junaid.GoogleGemini.Net.Infrastructure.Utilities;
+using Junaid.GoogleGemini.Net.Models.Requests;
 using Junaid.GoogleGemini.Net.Services.Interfaces;
 using Microsoft.Extensions.AI;
 using OpenTelemetry.Metrics;
@@ -27,11 +28,11 @@ var app = builder.Build();
 
 // Plain text generation:  GET /generate?prompt=Write%20a%20haiku
 app.MapGet("/generate", async (IGeminiService gemini, string prompt) =>
-    Results.Ok((await gemini.GenerateAsync(prompt)).Text()));
+    Results.Ok((await gemini.GenerateAsync(prompt, Fast())).Text()));
 
 // Typed structured output: GET /recipe?dish=pancakes  -> JSON shaped like Recipe
 app.MapGet("/recipe", async (IGeminiService gemini, string dish) =>
-    Results.Ok(await gemini.GenerateAsync<Recipe>($"A simple recipe for {dish}.")));
+    Results.Ok(await gemini.GenerateAsync<Recipe>($"A simple recipe for {dish}.", Fast())));
 
 // Streaming: GET /stream?prompt=...  -> chunks streamed as they arrive
 app.MapGet("/stream", (IGeminiService gemini, string prompt, CancellationToken ct)
@@ -43,10 +44,15 @@ app.MapPost("/chat", async (IChatClient chat, ChatRequest request) =>
 
 app.Run();
 
+// gemini-3.5-flash defaults to a "high" thinking level, which can add tens of seconds (even >2 min)
+// of latency per call. For these simple demo endpoints we opt down to "low" so responses are snappy.
+// Drop this (or raise it) when you actually want deeper reasoning.
+static GeminiRequestOptions Fast() => new() { ThinkingLevel = GeminiConstants.ThinkingLevels.Low };
+
 static async IAsyncEnumerable<string> StreamText(
     IGeminiService gemini, string prompt, [EnumeratorCancellation] CancellationToken ct)
 {
-    await foreach (var chunk in gemini.StreamAsync(prompt, cancellationToken: ct))
+    await foreach (var chunk in gemini.StreamAsync(prompt, Fast(), ct))
     {
         var text = chunk.Text();
         if (!string.IsNullOrEmpty(text))

--- a/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/appsettings.json
+++ b/samples/Junaid.GoogleGemini.Net.AspNetCoreSample/appsettings.json
@@ -9,7 +9,7 @@
   "Gemini": {
     "ApiKey": "",
     "DefaultModel": "gemini-3.5-flash",
-    "TimeoutSeconds": 30,
+    "TimeoutSeconds": 120,
     "MaxRetries": 3,
     "RateLimit": {
       "Enabled": true,

--- a/tests/Junaid.GoogleGemini.Net.Tests/Gemini3SupportTests.cs
+++ b/tests/Junaid.GoogleGemini.Net.Tests/Gemini3SupportTests.cs
@@ -123,6 +123,13 @@ public class Gemini3SupportTests
         Assert.Contains("get_weather", body);
     }
 
+    [Fact]
+    public void DefaultTimeout_IsGenerousForThinkingModels()
+    {
+        // Gemini 3 thinking models can take >1 min; the old 30s default caused spurious timeouts.
+        Assert.Equal(100, new GeminiOptions().TimeoutSeconds);
+    }
+
     private static GeminiService CreateService(FakeHttpMessageHandler handler)
     {
         var httpClient = new HttpClient(handler) { BaseAddress = new Uri("https://example.test/v1beta/") };


### PR DESCRIPTION
Two fixes that came directly out of running the sample live against `gemini-3.5-flash`:

- **Default `TimeoutSeconds` 30 → 100.** Gemini 3 thinking models default to high reasoning depth; a single call can exceed a minute (one `/generate` hit >120s), so the old 30s default caused spurious `GeminiTimeoutException`s. `GeminiOptions` now sources the default from the constant.
- **Sample uses `ThinkingLevel.Low`** on `/generate`, `/recipe`, `/stream` so the demo is snappy — and shows off the beta.2 `thinkingLevel` knob. Sample `appsettings` timeout bumped to 120.

34/34 tests on net8.0 + net9.0 (added a default-timeout test). Bumped to `6.0.0-beta.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)