### PR TITLE
fix(ns2.0): make AddGemini work on .NET Framework + runtime smoke (beta.4)

### DIFF
--- a/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
+++ b/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
@@ -11,7 +11,7 @@
 		<Description>Microsoft.Extensions.AI adapters (IChatClient, IEmbeddingGenerator) for Junaid.GoogleGemini.Net — use Google Gemini anywhere the .NET AI abstractions are consumed. Built with AI: implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;Microsoft.Extensions.AI;IChatClient;AI;LLM;dotnet</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-beta.3</Version>
+		<Version>6.0.0-beta.4</Version>
 
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
+++ b/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
@@ -19,8 +19,13 @@
 		<Description>A production-ready .NET client for the Google Gemini API: resilient (retries + rate limiting), observable, and DI-native, with first-class ASP.NET Core ergonomics. Built with AI: the v6 modernization was implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;GenerativeAI;AI;LLM;GoogleAI;dotnet;aspnetcore;IChatClient</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-beta.3</Version>
+		<Version>6.0.0-beta.4</Version>
 		<PackageReleaseNotes>
+			6.0 beta.4: fix netstandard2.0 usage on .NET Framework. AddGemini's options validation
+			needs System.ComponentModel.Annotations, which the .NET Framework GAC ships at an older
+			version than required — so it's now declared as a netstandard2.0 dependency and deployed
+			automatically (previously threw FileNotFoundException on first use). Verified live on
+			.NET Framework 4.8. .NET Framework consumers should also enable AutoGenerateBindingRedirects.
 			6.0 beta.3: default request timeout raised from 30s to 100s. Gemini 3 "thinking" models
 			default to high reasoning depth and a single call can take well over a minute; the old
 			30s default caused spurious GeminiTimeoutExceptions. (Lower TimeoutSeconds, or set a lower
@@ -98,12 +103,16 @@
 		Polyfills for the netstandard2.0 target only:
 		- System.Text.Json: in-box on net8/9, a package here (brings the source generator too).
 		- Microsoft.Bcl.AsyncInterfaces: IAsyncEnumerable / IAsyncDisposable.
+		- System.ComponentModel.Annotations: in-box on net8/9, but on .NET Framework the GAC ships an
+		  older version than the options DataAnnotations validation binds against — declare it so it's
+		  deployed to .NET Framework consumers (otherwise AddGemini throws FileNotFoundException).
 		- PolySharp: generates compiler-required shims (init/record, required members, nullable and
 		  [EnumeratorCancellation] attributes) so modern C# compiles on the old surface. Dev-only.
 	-->
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
 		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+		<PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/samples/Junaid.GoogleGemini.Net.NetFrameworkSmoke/Junaid.GoogleGemini.Net.NetFrameworkSmoke.csproj
+++ b/samples/Junaid.GoogleGemini.Net.NetFrameworkSmoke/Junaid.GoogleGemini.Net.NetFrameworkSmoke.csproj
@@ -1,0 +1,38 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Runtime smoke test for the netstandard2.0 build on .NET Framework. The library multi-targets
+    net8.0;net9.0;netstandard2.0; this app forces the ns2.0 asset onto the classic .NET Framework
+    CLR to prove the polyfills (HttpPolyfills, PolySharp shims, the ns2.0 GeminiRetryHandler) and
+    System.Text.Json actually RUN there — not just compile.
+
+    Deliberately NOT added to Junaid.GoogleGemini.Net.sln: it can't build/run on the Linux CI
+    runners. Run on Windows:  set GeminiApiKey, then `dotnet run` from this folder.
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <!-- .NET Framework needs binding redirects to load the unified assembly versions that a
+         netstandard2.0 library (and its System.* deps) bind against. SDK-style net4x apps don't
+         emit these unless asked. Consumers on .NET Framework must do the same. -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <!-- Keep the smoke green regardless of code-style analyzers inherited from Directory.Build.props. -->
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Lets the project build even where the .NET Framework targeting pack isn't installed. -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="all" />
+    <!-- Note: System.ComponentModel.Annotations is NOT referenced here on purpose — it flows in
+         transitively from the library's netstandard2.0 dependencies, proving consumers get it
+         automatically. -->
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- References the multi-target library; on net48 NuGet resolves the netstandard2.0 asset. -->
+    <ProjectReference Include="..\..\Junaid.GoogleGemini.Net\Junaid.GoogleGemini.Net.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/Junaid.GoogleGemini.Net.NetFrameworkSmoke/Program.cs
+++ b/samples/Junaid.GoogleGemini.Net.NetFrameworkSmoke/Program.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Junaid.GoogleGemini.Net.Extensions;
+using Junaid.GoogleGemini.Net.Services.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+internal static class Program
+{
+    private static async Task<int> Main()
+    {
+        Console.WriteLine($"Runtime: {RuntimeInformation.FrameworkDescription}");
+
+        var key = Environment.GetEnvironmentVariable("GeminiApiKey");
+        if (string.IsNullOrWhiteSpace(key))
+        {
+            // The library assembly loaded and the DI extension is callable — that alone proves the
+            // netstandard2.0 build is usable on .NET Framework. Skip the network call.
+            Console.WriteLine("GeminiApiKey not set; skipping live call. (ns2.0 assembly loaded OK.)");
+            return 0;
+        }
+
+        var services = new ServiceCollection();
+        services.AddGemini(options =>
+        {
+            options.ApiKey = key;
+            options.DefaultModel = "gemini-2.5-flash";
+        });
+
+        using var provider = services.BuildServiceProvider();
+        var gemini = provider.GetRequiredService<IGeminiService>();
+
+        // Exercises the full ns2.0 runtime path on .NET Framework: HttpClient + the polyfilled
+        // GeminiRetryHandler + System.Text.Json (source-gen) deserialization.
+        var response = await gemini.GenerateAsync("Reply with exactly the word: pong");
+        var text = response.Text();
+        Console.WriteLine($"Live response: '{text}'  (finish={response.FinishReason})");
+
+        return string.IsNullOrWhiteSpace(text) ? 1 : 0;
+    }
+}

--- a/samples/Junaid.GoogleGemini.Net.NetFrameworkSmoke/README.md
+++ b/samples/Junaid.GoogleGemini.Net.NetFrameworkSmoke/README.md
@@ -1,0 +1,35 @@
+# .NET Framework runtime smoke test
+
+A tiny `net48` console that proves the library's **netstandard2.0** build actually *runs* on the
+classic .NET Framework CLR — not just that it compiles. It exercises the full path: DI registration,
+options validation, `HttpClient` + the polyfilled `GeminiRetryHandler`, and System.Text.Json
+source-generated (de)serialization.
+
+It is **not** part of `Junaid.GoogleGemini.Net.sln`, because it can't build/run on the Linux CI
+runners. Run it on Windows.
+
+## Run
+
+```powershell
+$env:GeminiApiKey = "your-key"   # omit to just verify the assembly loads (no network call)
+dotnet run --project samples/Junaid.GoogleGemini.Net.NetFrameworkSmoke
+```
+
+Expected with a key: `Live response: 'pong'  (finish=STOP)`.
+
+## What it verified (and the fix it produced)
+
+Running this surfaced a real .NET Framework-only issue that compile-only checks miss: the options
+`DataAnnotations` validation needs `System.ComponentModel.Annotations` **4.2.0.0**, but the Framework
+GAC ships an older version, so `AddGemini` threw `FileNotFoundException` on first use.
+
+Fix: the library now declares `System.ComponentModel.Annotations` as a **netstandard2.0 dependency**,
+so it's deployed to .NET Framework consumers automatically (this project relies on that transitive
+flow — note it has no explicit reference to it).
+
+## .NET Framework consumer checklist
+
+- Enable binding redirects (standard for net4x SDK-style apps):
+  `<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>`
+- That's it — the required `System.ComponentModel.Annotations` now comes in transitively with the
+  package.


### PR DESCRIPTION
Runs the netstandard2.0 build on .NET Framework 4.8 (new net48 smoke, not in the solution). Caught and fixed a real bug: AddGemini options validation needs System.ComponentModel.Annotations 4.2.0.0, absent from the Framework GAC -> FileNotFoundException. Fix declares it as an ns2.0 dependency so it deploys to .NET Framework consumers. Verified live ('pong' on .NET Framework 4.8). 34/34 unit tests. Bumped to 6.0.0-beta.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)