### PR TITLE
docs: refresh README + guides for Gemini 3 (beta.2-beta.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Get an API key from [Google AI Studio](https://aistudio.google.com/app/apikey), 
 {
   "Gemini": {
     "ApiKey": "your-api-key-here",
-    "DefaultModel": "gemini-2.5-flash",
-    "TimeoutSeconds": 30,
+    "DefaultModel": "gemini-3.5-flash",
+    "TimeoutSeconds": 100,
     "MaxRetries": 3,
     "RateLimit": { "Enabled": true, "RequestsPerMinute": 60 }
   }
@@ -120,11 +120,10 @@ var usage  = response.Usage;                    // PromptTokenCount, CandidatesT
 ```csharp
 var options = new GeminiRequestOptions
 {
-    Model = GeminiConstants.Models.Gemini25Pro,
-    Temperature = 0.7f,
+    Model = GeminiConstants.Models.Gemini35Flash,        // Gemini 3 (the default is gemini-3.5-flash)
     SystemInstruction = "You are a terse senior engineer.",
-    ThinkingBudget = 1024,        // Gemini 2.5+ reasoning budget
-    EnableGoogleSearch = true,    // ground answers with Google Search
+    ThinkingLevel = GeminiConstants.ThinkingLevels.Low,  // Gemini 3 reasoning depth (use ThinkingBudget on 2.5)
+    EnableGoogleSearch = true,                           // ground answers with Google Search
 };
 var grounded = await gemini.GenerateAsync("What shipped in .NET 9?", options);
 foreach (var q in grounded.Candidates?[0].GroundingMetadata?.WebSearchQueries ?? [])
@@ -132,6 +131,12 @@ foreach (var q in grounded.Candidates?[0].GroundingMetadata?.WebSearchQueries ??
 ```
 
 Convenience presets: `GeminiRequestOptions.Creative()`, `.Factual()`, `.Code()`, `.Fast()`.
+
+> **Gemini 3 ready.** Model names aren't allow-listed, so any current/future model works without a
+> library update. `ThinkingLevel` and `MediaResolution` are supported, and the model's encrypted
+> `thoughtSignature` is captured and can be replayed for multi-turn function calling via the
+> `Content`-based `ChatAsync`/`StreamChatAsync` overloads. Tip: Gemini 3 thinking models default to
+> deep reasoning — set a lower `ThinkingLevel` for latency-sensitive calls.
 
 ### Embeddings
 

--- a/docs/articles/files-and-caching.md
+++ b/docs/articles/files-and-caching.md
@@ -43,3 +43,7 @@ await caching.DeleteAsync(cache.Name!);
 ```
 
 The response's `Usage.CachedContentTokenCount` shows how many tokens were served from the cache.
+
+> **Note:** context caching requires a **billing-enabled** API key — the free tier allows zero
+> cached-content storage, so `CreateAsync` fails there with a `TotalCachedContentStorageTokensPerModelFreeTier`
+> error. Cached content also has a per-model **minimum token count** (e.g. ~1,024 for Gemini 2.5 Flash).

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -19,8 +19,8 @@ Get a key from [Google AI Studio](https://aistudio.google.com/app/apikey). Provi
 {
   "Gemini": {
     "ApiKey": "your-api-key",
-    "DefaultModel": "gemini-2.5-flash",
-    "TimeoutSeconds": 30,
+    "DefaultModel": "gemini-3.5-flash",
+    "TimeoutSeconds": 100,
     "MaxRetries": 3,
     "RateLimit": { "Enabled": true, "RequestsPerMinute": 60 }
   }

--- a/docs/articles/migration-v5-to-v6.md
+++ b/docs/articles/migration-v5-to-v6.md
@@ -51,6 +51,19 @@ catch (GeminiApiException ex) { var code = ex.StatusCode; var status = ex.Status
 - The client now targets the **v1beta** API by default (unlocks structured output, thinking,
   grounding, caching, the Files API).
 - Deprecated model fallbacks (e.g. `gemini-1.5-pro`) were removed; vision uses your default model.
+- The **default model is now `gemini-3.5-flash`** (a current GA model). Set `DefaultModel` /
+  `options.Model` to pin a specific model.
+- **Model names are no longer validated against an allow-list** — any current or future model
+  (e.g. the Gemini 3 family) works without a library update; the API rejects genuinely invalid names.
+- The **default request timeout is now 100s** (was 30s). Gemini 3 "thinking" models can take well
+  over a minute; lower `TimeoutSeconds` or set a lower `ThinkingLevel` for latency-sensitive work.
+- **No default temperature is forced** anymore. If you don't set `Temperature`, the model uses its
+  own default (1.0 on Gemini 3, which advises against lowering it).
+
+### .NET Framework
+The `netstandard2.0` build runs on .NET Framework 4.6.1+. Enable
+`<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>` in your app; the required
+`System.ComponentModel.Annotations` now flows in transitively.
 
 ## New in v6
 
@@ -61,3 +74,11 @@ catch (GeminiApiException ex) { var code = ex.StatusCode; var status = ex.Status
 - OpenTelemetry traces & metrics
 - `Microsoft.Extensions.AI` adapters (`IChatClient`, `IEmbeddingGenerator`)
 - `netstandard2.0` target
+
+### Gemini 3
+- `ThinkingLevel` (`minimal`/`low`/`medium`/`high`) — Gemini 3's reasoning control; mutually
+  exclusive with the 2.5-era `ThinkingBudget`.
+- `MediaResolution` for image/video/PDF parts.
+- The model's encrypted `thoughtSignature` is captured on response parts and can be **echoed back
+  for multi-turn function calling** via the new `Content`-based `ChatAsync`/`StreamChatAsync`
+  overloads (Gemini 3 returns HTTP 400 if a function-call signature isn't replayed).

--- a/docs/articles/structured-output.md
+++ b/docs/articles/structured-output.md
@@ -22,7 +22,7 @@ filled in only if you didn't set them:
 ```csharp
 var person = await gemini.GenerateAsync<Person>(
     "Pick a famous scientist.",
-    new GeminiRequestOptions { Model = "gemini-2.5-pro", Temperature = 0.2f });
+    new GeminiRequestOptions { Model = "gemini-3.5-flash", Temperature = 0.2f });
 ```
 
 ## Tips


### PR DESCRIPTION
Brings the docs in line with the beta.2-beta.4 changes: default model `gemini-3.5-flash`, default timeout 100s, model allow-list removed, no forced temperature, `ThinkingLevel`/`MediaResolution`, and `thoughtSignature` replay via the `Content`-based `ChatAsync` overloads. Also documents .NET Framework binding-redirect requirements and that context caching needs a billing-enabled key. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)