### PR TITLE
ci: bump actions to Node 24 versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ jobs:
     name: Build & Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # full history so Source Link can stamp the exact commit
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -44,12 +44,12 @@ jobs:
     # Only run for pushed version tags, never for branch pushes or PRs.
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x
@@ -30,7 +30,7 @@ jobs:
         run: dotnet tool update -g docfx
       - name: Build docs
         run: docfx docs/docfx.json
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs/_site
 
@@ -42,4 +42,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,8 +14,8 @@ jobs:
     name: Live integration tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
             8.0.x


### PR DESCRIPTION
GitHub is retiring Node 20 from runners (forced to Node 24 ~2026-06-16, removed ~2026-09-16). Bumps to current majors so the pipelines keep working and the deprecation warnings clear:

- `actions/checkout` v4 → v6
- `actions/setup-dotnet` v4 → v5
- `actions/upload-pages-artifact` v3 → v5
- `actions/deploy-pages` v4 → v5

Version pins only; no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)