### PR TITLE
release: 6.0.0

### DIFF
--- a/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
+++ b/Junaid.GoogleGemini.Net.Extensions.AI/Junaid.GoogleGemini.Net.Extensions.AI.csproj
@@ -11,7 +11,7 @@
 		<Description>Microsoft.Extensions.AI adapters (IChatClient, IEmbeddingGenerator) for Junaid.GoogleGemini.Net — use Google Gemini anywhere the .NET AI abstractions are consumed. Built with AI: implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;Microsoft.Extensions.AI;IChatClient;AI;LLM;dotnet</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-rc.1</Version>
+		<Version>6.0.0</Version>
 
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
+++ b/Junaid.GoogleGemini.Net/Junaid.GoogleGemini.Net.csproj
@@ -19,8 +19,14 @@
 		<Description>A production-ready .NET client for the Google Gemini API: resilient (retries + rate limiting), observable, and DI-native, with first-class ASP.NET Core ergonomics. Built with AI: the v6 modernization was implemented end-to-end by Claude (Anthropic) — see the README.</Description>
 		<PackageTags>GoogleGemini;Gemini;GenerativeAI;AI;LLM;GoogleAI;dotnet;aspnetcore;IChatClient</PackageTags>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<Version>6.0.0-rc.1</Version>
+		<Version>6.0.0</Version>
 		<PackageReleaseNotes>
+			6.0.0: a ground-up modernization of the v5 client — resilient (correct retry/backoff +
+			client-side rate limiting), observable (OpenTelemetry traces &amp; metrics), DI-native, with
+			generic structured output (GenerateAsync&lt;T&gt;), the full modern Gemini surface including
+			Gemini 3 (function calling with thoughtSignature replay, thinkingLevel, grounding, Files,
+			caching), Microsoft.Extensions.AI adapters (IChatClient/IEmbeddingGenerator), and a
+			netstandard2.0 build verified on .NET Framework 4.8. See the v5-to-v6 migration guide.
 			6.0.0-rc.1: release candidate for 6.0.0. The v6 surface is feature-complete and verified
 			live against the Gemini API — Gemini 3 function calling with thoughtSignature replay,
 			grounding, Files API, embeddings, structured output, streaming, and IChatClient — and the


### PR DESCRIPTION
Promotes `6.0.0-rc.1` to **stable**. No code changes since rc.1 — version bump only. The v6 surface is feature-complete, live-verified against the Gemini API, and the netstandard2.0 build is verified on .NET Framework 4.8.

34/34 unit tests green (net8.0 + net9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)