### PR TITLE
test: fix flaky telemetry-activity test under parallel execution

### DIFF
--- a/tests/Junaid.GoogleGemini.Net.Tests/Infrastructure/GeminiClientTests.cs
+++ b/tests/Junaid.GoogleGemini.Net.Tests/Infrastructure/GeminiClientTests.cs
@@ -139,13 +139,14 @@ public class GeminiClientTests
         var handler = FakeHttpMessageHandler.RespondWith(HttpStatusCode.OK, json);
         var client = CreateClient(handler);
 
+        // A unique model name keeps this assertion isolated from activities that other test classes
+        // emit in parallel onto the same (process-global) ActivitySource.
         await client.PostAsync<GenerateContentRequest, GenerateContentResponse>(
-            "models/gemini-2.5-pro:generateContent", new GenerateContentRequest());
+            "models/gemini-activity-probe:generateContent", new GenerateContentRequest());
 
-        var activity = Assert.Single(activities);
-        Assert.Equal("generateContent gemini-2.5-pro", activity.DisplayName);
+        var activity = Assert.Single(activities, a => a.DisplayName == "generateContent gemini-activity-probe");
         Assert.Equal("gemini", activity.GetTagItem("gen_ai.system"));
-        Assert.Equal("gemini-2.5-pro", activity.GetTagItem("gen_ai.request.model"));
+        Assert.Equal("gemini-activity-probe", activity.GetTagItem("gen_ai.request.model"));
         Assert.Equal(5, activity.GetTagItem("gen_ai.usage.input_tokens"));
     }
 }


### PR DESCRIPTION
`PostAsync_EmitsActivity_WithGenAiTags` used `Assert.Single` over all activities captured from the process-global `ActivitySource`. When another test class ran in parallel and emitted its own activity (`gemini-2.5-flash`), it leaked into this test's listener and failed the assertion (caught in CI). Fix: use a unique probe model name and assert on the single activity matching it. Test-only — no library change, `6.0.0` package unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)